### PR TITLE
feat: SwiftUI property wrappers, concurrency audit, and UIKit demo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,3 +55,26 @@ jobs:
             -destination "platform=iOS Simulator,name=${{ steps.simulator.outputs.simulator_name }}" \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
+
+  release:
+    name: Create Release Tag
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create version tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Swift SDK for [PocketBase](https://pocketbase.io/) (v0.32.0). SPM library exposing a `PocketBase` product, targeting iOS 17+ / macOS 14+ with Swift 6.1 tools. Depends on Alamofire (HTTP) and Recouse/EventSource (SSE for realtime).
+Swift SDK for [PocketBase](https://pocketbase.io/) (v0.37.3). SPM library exposing a `PocketBase` product, targeting iOS 17+ / macOS 14+ with Swift 6.1 tools. Depends on Alamofire (HTTP) and Recouse/EventSource (SSE for realtime).
 
 ## Commands
 
@@ -35,7 +35,9 @@ Two parallel APIs for CRUD exist and must be kept in sync when changing request 
 1. **Untyped on `PocketBase`** — `pb.getOne/getList/create/update/delete(collection:model:...)`. Caller passes the model type each call.
 2. **Typed `Collection<T>`** — obtained via `pb.collection("name")`. Binds the generic once; thin wrapper around the same endpoints. Also exposes `realtime(...)` for that specific collection.
 
-Both paths build URLs through a private `buildURL` that appends `expand` / `filter` query items, then delegate to `HttpClient`. If you add a new query parameter, update **both** call sites (see `pb.swift` and `Collection` in the same file).
+Both paths build URLs through a private `buildURL` method that appends `expand` query items, then delegate to `HttpClient`. **`buildURL` is duplicated** — `PocketBase` and `Collection` each have their own private copy (in the same file). If you add a new query parameter or fix a URL bug, update **both**.
+
+Exception: `getList` on both classes constructs URLs inline with `URLComponents` rather than calling `buildURL`, because it needs multiple query items (`page`, `perPage`, `expand`, `filter`). Keep this inconsistency in mind when touching URL construction.
 
 ### Model protocols (`model.swift`, `pb.swift`)
 
@@ -48,11 +50,30 @@ Both paths build URLs through a private `buildURL` that appends `expand` / `filt
 
 `auth.swift` extends `PocketBase` with password / refresh / reset / verify endpoints. On successful `authWithPassword`, the token and user id are persisted via `SecureStorage` (`pocketbase_user_token`, `pocketbase_user_id` Keychain service `io.pocketbase.swift.sdk`). `HttpClient`'s `RequestInterceptor.adapt` reads that token and attaches `Authorization` on every request (user token preferred, admin token as fallback). `signOut()` clears both.
 
+**Admin auth gap**: `SecureStorage` has full admin token support (`storeAdminToken`, `adminToken`, `adminId`) and the interceptor falls back to the admin token, but there is no public `authWithPassword` for the admin collection. Admin token must be set manually via `secureStorage.storeAdminToken(...)` for now.
+
 **Test-environment keychain shim**: `SecureStorage` detects `XCTestConfigurationFilePath` under `#if DEBUG` and transparently swaps Keychain for `UserDefaults` keys prefixed `test_`. This sidesteps missing keychain entitlements in SPM test hosts — do not "simplify" it away. When writing tests that assert auth state, they rely on this.
 
 ### Realtime (`realtime.swift`)
 
 `Realtime<T>` wraps `EventSource` for SSE against `/api/realtime`. Flow: subscribe → receive `PB_CONNECT` event → decode `clientId` → POST `{clientId, subscriptions: ["<collection>/<record>"]}` back to `/api/realtime` to register. Subsequent events are decoded as `RealtimeEvent<T>` and delivered to `onEvent`. The post-back is done with raw `URLSession` (not `HttpClient`), so it does **not** include the auth header — keep that in mind if collection API rules require auth.
+
+### Logging (`logging.swift`)
+
+All classes use `os.Logger` with subsystem `com.drewalth.pocketbase-swift-sdk` and per-class categories (`PocketBase`, `HttpClient`, `Collection`, `RealTime`, `SecureStorage`). Filter logs in Console.app by this subsystem.
+
+### `Collection<T>` creates its own `HttpClient`
+
+Each `pb.collection("name")` call creates a new `Collection<T>` with its own `HttpClient` and thus its own Alamofire `Session`. This means each collection has a separate URL session and interceptor chain. Don't worry about reusing a single session — the current design intentionally isolates per-collection.
+
+### Test organization
+
+Tests live in `Tests/pocketbase-swift-sdkTests/` and are organized by feature file:
+- `test-models.swift` — shared test record types (`TestUser`, `TestPost`, `Bookmark`, etc.)
+- `authentication.swift`, `crud_operations.swift`, `fluent_api.swift`, `expand.swift`, `filters.swift`, `realtime.swift` — integration tests hitting the live test server
+- `type_inference.swift` — compile-time type inference checks
+
+All tests are integration tests requiring the test server. Add new test models to `test-models.swift`. The test server must be running (`make start_test_server` or `make start_test_server_fresh`).
 
 ### Query builders
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,78 @@
-# Pocketbase Swift SDK
+# PocketBase Swift SDK
 
-A Swift SDK for [Pocketbase](https://pocketbase.io/) v0.37.3.
+A lightweight, idiomatic Swift SDK for [PocketBase](https://pocketbase.io/) with SwiftUI property
+wrappers and UIKit compatibility.
 
-[![CI](https://github.com/drewalth/pocketbase-swift-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/drewalth/pocketbase-swift-sdk/actions/workflows/ci.yaml) [![Swift](https://img.shields.io/badge/Swift-6.0-orange?style=flat-square)](https://img.shields.io/badge/Swift-6.0-Orange?style=flat-square)
-[![Platforms](https://img.shields.io/badge/Platforms-macOS_iOS-yellowgreen?style=flat-square)](https://img.shields.io/badge/Platforms-macOS_iOS-YellowGreen?style=flat-square)
+[![CI](https://github.com/drewalth/pocketbase-swift-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/drewalth/pocketbase-swift-sdk/actions/workflows/ci.yaml)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdrewalth%2Fpocketbase-swift-sdk%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/drewalth/pocketbase-swift-sdk)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdrewalth%2Fpocketbase-swift-sdk%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/drewalth/pocketbase-swift-sdk)
 
+- [Overview](#overview)
+- [Quick start](#quick-start)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Example app](#example-app)
+- [License](#license)
 
-## Features
+## Overview
 
-- ✅ Generic user authentication (supports any model)
-- ✅ User authentication (sign up, sign in, sign out)
-- ✅ Token refresh
-- ✅ Password reset
-- ✅ CRUD operations
-- ✅ Realtime subscriptions
-- ✅ Type-safe data models
-- ✅ Automatic token management (stores tokens securely)
+The SDK provides a type-safe, concurrency-first API for PocketBase's REST and SSE endpoints. Define
+your models as `Codable` structs, and property wrappers like `@PBQuery` and `@PBAuthState` keep your
+views in sync — similar to SwiftData's `@Query` but driven by your PocketBase server:
 
+```swift
+@PBQuery(collection: "posts", sort: \Post.created, order: .reverse)
+private var posts: [Post]
+```
 
-> Note: This is a work in progress. The SDK is not yet have 100% feature parity with the [js-sdk](https://github.com/pocketbase/js-sdk) but it's close.
-> Any contributions are welcome!
+The core library has **zero UI framework dependencies** — it works from SwiftUI, UIKit, or a
+headless Swift target.
 
-## Motivation
+## Quick start
 
-Pocketbase is a great framework for quick prototyping and small scale applications. In an ideal world, Pocketbase would generate Swagger/OpenAPI documentation, but currently it doesn't. And there is [no plan](https://github.com/pocketbase/pocketbase/issues/945) to add it in the future. 
+Define a model and provide a `PocketBase` instance to the SwiftUI environment:
 
-This SDK aims to make it easier to use Pocketbase with Swift projects.
+```swift
+import PocketBase
+import SwiftUI
+
+struct Post: PBCollection {
+  let id: String
+  let title: String
+  let created: String
+  let updated: String
+  let collectionId: String
+  let collectionName: String
+}
+
+@main
+struct MyApp: App {
+  @State private var pocketBase = PocketBase(baseURL: "http://127.0.0.1:8090")
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environment(\.pocketBase, pocketBase)
+    }
+  }
+}
+```
+
+Then fetch and display data with `@PBQuery`:
+
+```swift
+struct ContentView: View {
+  @PBQuery(collection: "posts", sort: \Post.created, order: .reverse)
+  private var posts: [Post]
+
+  var body: some View {
+    List(posts) { post in
+      Text(post.title)
+    }
+    .refreshable { $posts.refresh() }
+  }
+}
+```
 
 ## Installation
 
@@ -33,300 +80,230 @@ Add the package to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/drewalth/pocketbase-swift-sdk.git", from: "1.0.0")
+  .package(url: "https://github.com/drewalth/pocketbase-swift-sdk.git", from: "1.0.0")
 ],
 targets: [
-    .target(name: "YourApp", dependencies: [.product(name: "PocketBase", package: "pocketbase-swift-sdk")])
+  .target(name: "YourApp", dependencies: [.product(name: "PocketBase", package: "pocketbase-swift-sdk")])
 ]
 ```
 
+Or in Xcode: **File → Add Package Dependencies...** and search for
+`https://github.com/drewalth/pocketbase-swift-sdk`.
+
 ## Usage
 
-### SwiftUI
+### Data models
 
 ```swift
-// Add the PocketBase instance to the environment
-private struct PB: EnvironmentKey {
-  static let defaultValue = PocketBase(baseURL: "http://127.0.0.1:8090")
+// A model for any PocketBase collection
+struct Bookmark: PBCollection {
+  let id: String
+  let title: String
+  let url: String
+  let created: String
+  let updated: String
+  let collectionId: String
+  let collectionName: String
 }
 
-extension EnvironmentValues {
-  var pocketBase: PocketBase {
-    get {
-      self[PB.self]
-    } set {
-      self[PB.self] = newValue
-    }
-  }
-}
-
-// Access the PocketBase instance in your views
-struct ContentView: View {
-    @Environment(\.pocketBase) var pocketBase
-    @State private var posts: [Post] = []
-
-    var body: some View {
-        List(posts, id: \.id) { post in
-            Text(post.title)
-        }
-        .task {
-            do {
-                let postCollection: Collection<Post> = pocketBase.collection("posts")
-                let postResult = try await postCollection.getList()
-                posts = postResult.items
-            } catch {
-                print(error)
-            }
-        }
-    }
-}
-```
-
-> See the [example project](./example) for a more complete example.
-
-### Data Models
-
-The SDK uses generics to support any user model that conforms to `PBIdentifiableCollection`. You need to define your own User models:
-
-```swift
-// Define your User model
+// For user/auth models, use PBIdentifiableCollection
 struct User: PBIdentifiableCollection {
-    let id: String
-    let email: String
-    let username: String?
-    let name: String?
-    let avatar: String?
-    let verified: Bool
-    let created: String
-    let updated: String
-    let collectionId: String
-    let collectionName: String
-    // Add any additional fields your PocketBase user collection has
+  let id: String
+  let email: String
+  let name: String?
+  let verified: Bool
+  let created: String
+  let updated: String
+  let collectionId: String
+  let collectionName: String
 }
 ```
 
-### Authentication
-
-The SDK provides comprehensive authentication functionality with generic support:
-
-#### User Authentication
-
-```swift
-// Sign up a new user
-let createUserDto = CreateUser(
-    email: "new@drewalth.com",
-    name: "Test User",
-    password: "password123",
-    passwordConfirm: "password123")
-let authResult = try await pb.signUp(dto: createUserDto, userType: User.self)
-
-// Sign in with email/username and password
-let authResult = try await pb.authWithPassword(
-    email: "user@example.com",
-    password: "password123",
-    userType: User.self
-)
-
-// Refresh authentication token
-let refreshResult = try await pb.authRefresh(userType: User.self)
-
-// Check authentication status
-if pb.isAuthenticated {
-    print("User is authenticated")
-    print("User ID: \(pb.currentUserId ?? "Unknown")")
-}
-
-// Sign out
-pb.signOut()
-```
-
-#### Password Reset and Email Verification
-
-```swift
-// Request password reset
-try await pb.requestPasswordReset(email: "user@example.com")
-
-// Confirm password reset (with token from email)
-try await pb.confirmPasswordReset(
-    token: "reset_token_from_email",
-    password: "newpassword",
-    passwordConfirm: "newpassword"
-)
-
-// Request email verification
-try await pb.requestVerification(email: "user@example.com")
-
-// Confirm email verification (with token from email)
-try await pb.confirmVerification(token: "verification_token_from_email")
-```
-
-### CRUD Operations
-
-```swift
-let bookmarksCollection = pb.collection("bookmarks")
-
-// Get a single record
-let bookmark = try await bookmarksCollection.getOne(id: "e849z3g13jls740")
-
-// Get a list of records
-let bookmarks = try await bookmarksCollection.getList()
-
-// Create a new record
-let newBookmark = try await bookmarksCollection.create(record: Bookmark(
-    title: "My First Bookmark",
-    url: "https://www.google.com"
-))
-
-// Update a record
-let updatedBookmark = try await bookmarksCollection.update(
-    id: newBookmark.id,
-    record: Bookmark(
-        title: "My Updated Bookmark",
-        url: "https://www.google.com"
-    )
-)
-
-// Delete a record
-try await bookmarksCollection.delete(id: newBookmark.id)
-```
-
-### Expand Functionality
-
-The SDK provides powerful expand functionality to include related data in your queries:
-
-#### Basic Expansion
-
-```swift
-// Expand a single field
-let expandQuery = ExpandQuery("author")
-let posts = try await pb.getList(
-    collection: "posts",
-    model: Post.self,
-    expand: expandQuery
-)
-
-// Expand multiple fields
-let expandQuery = ExpandQuery("author", "category", "tags")
-let posts = try await pb.getList(
-    collection: "posts",
-    model: Post.self,
-    expand: expandQuery
-)
-```
-
-#### Nested Expansion
-
-```swift
-// Expand nested relationships
-let expandQuery = ExpandQuery("author.profile", "category.parent")
-let posts = try await pb.getList(
-    collection: "posts",
-    model: Post.self,
-    expand: expandQuery
-)
-```
-
-#### Builder Pattern
-
-```swift
-// Use the builder pattern for complex expansions
-let expandQuery = ExpandBuilder()
-    .field("author")
-    .field("category")
-    .nested("author.profile")
-    .nested("category.parent")
-    .build()
-
-let posts = try await pb.getList(
-    collection: "posts",
-    model: Post.self,
-    expand: expandQuery
-)
-```
-
-#### Fluent API with Expand
+### CRUD operations
 
 ```swift
 let posts: Collection<Post> = pb.collection("posts")
 
-// Expand with fluent API
-let expandQuery = ExpandQuery("author", "category")
-let result = try await posts.getList(expand: expandQuery)
+// List
+let result = try await posts.getList()
+for post in result.items { /* ... */ }
 
-// Expand on single record
-let post = try await posts.getOne(
-    id: "post-id",
-    expand: ExpandQuery("author.profile")
-)
+// Single
+let post = try await posts.getOne(id: "e849z3g13jls740")
+
+// Create
+let newPost = try await posts.create(record: Post(/* ... */))
+
+// Update
+let updated = try await posts.update(id: newPost.id, record: Post(/* ... */))
+
+// Delete
+try await posts.delete(id: newPost.id)
 ```
 
-#### Conditional Expansion
+All CRUD methods are also available directly on `PocketBase` without creating a `Collection`:
 
 ```swift
-let builder = ExpandBuilder()
-
-if shouldIncludeAuthor {
-    builder.field("author")
-}
-
-if shouldIncludeCategory {
-    builder.field("category")
-}
-
-let expandQuery = builder.build()
-let posts = try await pb.getList(
-    collection: "posts",
-    model: Post.self,
-    expand: expandQuery
-)
+let result = try await pb.getList(collection: "posts", model: Post.self)
 ```
 
-### Realtime
+### Authentication
 
 ```swift
-let realtime = pb.realtime(
-    collection: "bookmarks",
-    record: "*",
-    onConnect: {
-        print("Connected to realtime")
-    },
-    onDisconnect: {
-        print("Disconnected from realtime")
-    },
-    onEvent: { event in
-        print("Received event: \(event.action) for record: \(event.record)")
+// Sign in
+let auth = try await pb.authWithPassword(
+  email: "user@example.com", password: "password", userType: User.self)
+
+// Sign up
+let newUser = try await pb.signUp(
+  dto: CreateUser(email: "...", name: "...", password: "...", passwordConfirm: "..."),
+  userType: User.self)
+
+// Sign out
+pb.signOut()
+
+// Password reset
+try await pb.requestPasswordReset(email: "user@example.com")
+try await pb.confirmPasswordReset(token: "...", password: "...", passwordConfirm: "...")
+```
+
+Tokens are stored in the Keychain and automatically attached to every request. In the simulator, the
+SDK transparently falls back to `UserDefaults`.
+
+#### SwiftUI auth state
+
+```swift
+struct AuthView: View {
+  @PBAuthState private var auth
+
+  var body: some View {
+    if auth.isAuthenticated {
+      Text("Signed in as \(auth.userId ?? "")")
+    } else {
+      LoginFormView()
     }
-)
+  }
+}
+```
+
+### Sorting
+
+```swift
+// Keypath-based
+let posts = try await pb.collection("posts").getList(
+  sort: PBSortQuery(PBSortDescriptor(\Post.created, order: .reverse)))
+
+// Multiple sort fields
+let sort = PBSortQuery(
+  PBSortDescriptor(\Post.category, order: .forward),
+  PBSortDescriptor(\Post.created, order: .reverse))
+```
+
+`@PBQuery` supports keypath sort directly:
+
+```swift
+@PBQuery(collection: "posts", sort: \Post.created, order: .reverse)
+private var posts: [Post]
+```
+
+### Filtering
+
+```swift
+// Type-safe filter builder
+let filter = FiltersQuery()
+  .greaterThan("views", 100)
+  .equals("status", "published")
+
+let result = try await pb.collection("posts").getList(filters: filter)
+
+// Or use the builder pattern
+let filter = FilterBuilder()
+  .greaterThan("views", 100)
+  .equals("status", "published")
+  .build()
+```
+
+Combine filters with `@PBQuery`:
+
+```swift
+@PBQuery(
+  collection: "posts",
+  filter: FiltersQuery().equals("status", "published"),
+  sort: \Post.created, order: .reverse)
+private var publishedPosts: [Post]
+```
+
+### Expanding relations
+
+```swift
+// Expand a single relation
+let posts = try await pb.collection("posts").getList(expand: ExpandQuery("author"))
+
+// Expand nested relations
+let posts = try await pb.collection("posts").getList(expand: ExpandQuery("author.profile"))
+
+// Builder pattern
+let expand = ExpandBuilder()
+  .field("author")
+  .nested("author.profile")
+  .build()
+```
+
+### Realtime (SSE)
+
+```swift
+let realtime = pb.realtime(collection: "bookmarks", onEvent: { (event: RealtimeEvent<Bookmark>) in
+  switch event.action {
+  case .create: print("Created:", event.record.title)
+  case .update: print("Updated:", event.record.title)
+  case .delete: print("Deleted:", event.record.id)
+  }
+})
 
 try await realtime.subscribe()
 
-// Unsubscribe from realtime
+// Later
 realtime.unsubscribe()
 ```
 
-## Data Models
-
-Define your data models by conforming to `PBCollection`:
+Enable realtime on `@PBQuery` to automatically refresh the list when server data changes:
 
 ```swift
-struct Bookmark: PBCollection {
-    let id: String
-    let title: String
-    let url: String
-    let created: String
-    let updated: String
-    let collectionId: String
-    let collectionName: String
+@PBQuery(collection: "posts", sort: \Post.created, order: .reverse, realtime: true)
+private var posts: [Post]
+```
+
+### UIKit
+
+The SDK core has no SwiftUI dependency. Use it from UIKit with async/await:
+
+```swift
+import PocketBase
+import UIKit
+
+final class PostsViewController: UITableViewController {
+  private let pocketBase = PocketBase(baseURL: "http://127.0.0.1:8090")
+  private var posts: [Post] = []
+
+  private func fetch() async {
+    do {
+      let result = try await pocketBase.collection("posts").getList(
+        sort: PBSortQuery(PBSortDescriptor(\Post.created, order: .reverse)))
+      posts = result.items
+      tableView.reloadData()
+    } catch {
+      // handle error
+    }
+  }
 }
 ```
 
-For models that need an `id` property (like User and Admin), use `PBIdentifiableCollection`:
+## Example app
 
-```swift
-struct User: PBIdentifiableCollection {
-    let id: String
-    let email: String
-    // ... other properties
-}
-```
+The [example app](./example) demonstrates the full API surface — including `@PBQuery`,
+`@PBAuthState`, authentication flows, realtime subscriptions, and a UIKit screen — against a local
+PocketBase server. Open it with `cd example && xed .`.
 
+## License
+
+This library is released under the MIT license. See [LICENSE](LICENSE) for details.

--- a/Sources/pocketbase-swift-sdk/auth.swift
+++ b/Sources/pocketbase-swift-sdk/auth.swift
@@ -15,7 +15,7 @@ extension PocketBase {
         userType _: T.Type)
     async throws -> AuthModel<T> {
         let path = "/api/collections/users/auth-with-password"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         let body: [String: String] = ["password": password, "identity": email]
 
         logger.info("POST \(urlString) - Authenticating user")
@@ -31,7 +31,7 @@ extension PocketBase {
     public func signUp<T: PBIdentifiableCollection>(dto: PBCreateUser, userType _: T.Type)
     async throws -> T {
         let path = "/api/collections/users/records"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
 
         logger.info("POST \(urlString) - Creating new user account")
         let result: T = try await httpClient.post(urlString, input: dto, output: T.self).get()
@@ -42,7 +42,7 @@ extension PocketBase {
     /// Refresh the user authentication token
     public func authRefresh<T: PBIdentifiableCollection>(userType _: T.Type) async throws -> AuthRefreshResponse<T> {
         let path = "/api/collections/users/auth-refresh"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
 
         logger.info("POST \(urlString) - Refreshing user auth token")
         let result: AuthRefreshResponse<T> = try await httpClient.post(
@@ -59,7 +59,7 @@ extension PocketBase {
     /// Request password reset
     public func requestPasswordReset(email: String) async throws -> PBEmptyEntity {
         let path = "/api/collections/users/request-password-reset"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         let body = ["email": email]
 
         logger.info("POST \(urlString) - Requesting password reset")
@@ -73,7 +73,7 @@ extension PocketBase {
         passwordConfirm: String)
     async throws -> PBEmptyEntity {
         let path = "/api/collections/users/confirm-password-reset"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         let body = [
             "token": token,
             "password": password,
@@ -87,7 +87,7 @@ extension PocketBase {
     /// Request email verification
     public func requestVerification(email: String) async throws -> PBEmptyEntity {
         let path = "/api/collections/users/request-verification"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         let body = ["email": email]
 
         logger.info("POST \(urlString) - Requesting email verification")
@@ -97,7 +97,7 @@ extension PocketBase {
     /// Confirm email verification
     public func confirmVerification(token: String) async throws -> PBEmptyEntity {
         let path = "/api/collections/users/confirm-verification"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         let body = ["token": token]
 
         logger.info("POST \(urlString) - Confirming email verification")
@@ -107,7 +107,7 @@ extension PocketBase {
     /// Get available authentication methods
     public func getAuthMethods() async throws -> AuthMethodsList {
         let path = "/api/collections/users/auth-methods"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
 
         logger.info("GET \(urlString) - Getting auth methods")
         return try await httpClient.get(urlString, output: AuthMethodsList.self).get()

--- a/Sources/pocketbase-swift-sdk/auth_state.swift
+++ b/Sources/pocketbase-swift-sdk/auth_state.swift
@@ -1,0 +1,89 @@
+//
+//  auth_state.swift
+//  PocketBase
+//
+
+#if canImport(SwiftUI)
+    import SwiftUI
+
+    // MARK: - PBAuthInfo
+
+    public struct PBAuthInfo {
+        public let isAuthenticated: Bool
+        public let userId: String?
+    }
+
+    // MARK: - PBAuthProjection
+
+    public struct PBAuthProjection {
+        public let isAuthenticated: Bool
+        public let userId: String?
+        public let error: (any Error)?
+        public let refresh: () -> Void
+    }
+
+    // MARK: - PBAuthState
+
+    @propertyWrapper
+    public struct PBAuthState: DynamicProperty {
+
+        // MARK: Lifecycle
+
+        public init() {
+            self._isAuthenticated = State(initialValue: false)
+            self._userId = State(initialValue: nil)
+            self._error = State(initialValue: nil)
+            self._refreshToken = State(initialValue: 0)
+            self._lastRefreshToken = State(initialValue: 0)
+        }
+
+        // MARK: Public
+
+        public var wrappedValue: PBAuthInfo {
+            PBAuthInfo(isAuthenticated: isAuthenticated, userId: userId)
+        }
+
+        public var projectedValue: PBAuthProjection {
+            PBAuthProjection(
+                isAuthenticated: isAuthenticated,
+                userId: userId,
+                error: error,
+                refresh: { refreshToken += 1 }
+            )
+        }
+
+        // MARK: Internal
+
+        public mutating func update() {
+            guard let pb = pocketBase else {
+                error = PBError.missingEnvironment
+                return
+            }
+
+            error = nil
+
+            let needsRefresh = refreshToken != lastRefreshToken
+            if needsRefresh {
+                lastRefreshToken = refreshToken
+            }
+
+            let currentAuth = pb.isAuthenticated
+            let currentId = pb.currentUserId
+
+            if needsRefresh || isAuthenticated != currentAuth || userId != currentId {
+                isAuthenticated = currentAuth
+                userId = currentId
+            }
+        }
+
+        // MARK: Private
+
+        @Environment(\.pocketBase) private var pocketBase
+
+        @State private var isAuthenticated: Bool
+        @State private var userId: String?
+        @State private var error: (any Error)?
+        @State private var refreshToken: Int
+        @State private var lastRefreshToken: Int
+    }
+#endif

--- a/Sources/pocketbase-swift-sdk/auth_state.swift
+++ b/Sources/pocketbase-swift-sdk/auth_state.swift
@@ -8,9 +8,17 @@
 
     // MARK: - PBAuthInfo
 
-    public struct PBAuthInfo {
-        public let isAuthenticated: Bool
-        public let userId: String?
+    public enum PBAuthInfo {
+        case authenticated(userId: String)
+        case notAuthenticated
+
+        public var isAuthenticated: Bool {
+            if case .authenticated = self { true } else { false }
+        }
+
+        public var userId: String? {
+            if case .authenticated(let id) = self { id } else { nil }
+        }
     }
 
     // MARK: - PBAuthProjection
@@ -40,7 +48,11 @@
         // MARK: Public
 
         public var wrappedValue: PBAuthInfo {
-            PBAuthInfo(isAuthenticated: isAuthenticated, userId: userId)
+            if isAuthenticated, let userId {
+                .authenticated(userId: userId)
+            } else {
+                .notAuthenticated
+            }
         }
 
         public var projectedValue: PBAuthProjection {

--- a/Sources/pocketbase-swift-sdk/auth_state.swift
+++ b/Sources/pocketbase-swift-sdk/auth_state.swift
@@ -8,7 +8,7 @@
 
     // MARK: - PBAuthInfo
 
-    public enum PBAuthInfo {
+    public enum PBAuthInfo: Sendable {
         case authenticated(userId: String)
         case notAuthenticated
 
@@ -30,6 +30,20 @@
         public let refresh: () -> Void
     }
 
+    // MARK: - AuthStorage
+
+    // @unchecked Sendable: all mutable state is accessed exclusively from @MainActor
+    // via PBAuthState's @State storage and update() method.
+    // @Observable enables SwiftUI to track property-level mutations on this reference type.
+    @Observable
+    private final class AuthStorage: @unchecked Sendable {
+        var isAuthenticated = false
+        var userId: String?
+        var error: (any Error)?
+        var refreshToken = 0
+        var lastRefreshToken = 0
+    }
+
     // MARK: - PBAuthState
 
     @propertyWrapper
@@ -38,17 +52,13 @@
         // MARK: Lifecycle
 
         public init() {
-            self._isAuthenticated = State(initialValue: false)
-            self._userId = State(initialValue: nil)
-            self._error = State(initialValue: nil)
-            self._refreshToken = State(initialValue: 0)
-            self._lastRefreshToken = State(initialValue: 0)
+            self._storage = State(initialValue: AuthStorage())
         }
 
         // MARK: Public
 
         public var wrappedValue: PBAuthInfo {
-            if isAuthenticated, let userId {
+            if storage.isAuthenticated, let userId = storage.userId {
                 .authenticated(userId: userId)
             } else {
                 .notAuthenticated
@@ -57,10 +67,10 @@
 
         public var projectedValue: PBAuthProjection {
             PBAuthProjection(
-                isAuthenticated: isAuthenticated,
-                userId: userId,
-                error: error,
-                refresh: { refreshToken += 1 }
+                isAuthenticated: storage.isAuthenticated,
+                userId: storage.userId,
+                error: storage.error,
+                refresh: { [storage] in storage.refreshToken += 1 }
             )
         }
 
@@ -68,34 +78,29 @@
 
         public mutating func update() {
             guard let pb = pocketBase else {
-                error = PBError.missingEnvironment
+                storage.error = PBError.missingEnvironment
                 return
             }
 
-            error = nil
+            storage.error = nil
 
-            let needsRefresh = refreshToken != lastRefreshToken
+            let needsRefresh = storage.refreshToken != storage.lastRefreshToken
             if needsRefresh {
-                lastRefreshToken = refreshToken
+                storage.lastRefreshToken = storage.refreshToken
             }
 
             let currentAuth = pb.isAuthenticated
             let currentId = pb.currentUserId
 
-            if needsRefresh || isAuthenticated != currentAuth || userId != currentId {
-                isAuthenticated = currentAuth
-                userId = currentId
+            if needsRefresh || storage.isAuthenticated != currentAuth || storage.userId != currentId {
+                storage.isAuthenticated = currentAuth
+                storage.userId = currentId
             }
         }
 
         // MARK: Private
 
         @Environment(\.pocketBase) private var pocketBase
-
-        @State private var isAuthenticated: Bool
-        @State private var userId: String?
-        @State private var error: (any Error)?
-        @State private var refreshToken: Int
-        @State private var lastRefreshToken: Int
+        @State private var storage: AuthStorage
     }
 #endif

--- a/Sources/pocketbase-swift-sdk/environment.swift
+++ b/Sources/pocketbase-swift-sdk/environment.swift
@@ -6,19 +6,7 @@
 #if canImport(SwiftUI)
     import SwiftUI
 
-    // MARK: - PocketBaseEnvironmentKey
-
-    private struct PocketBaseEnvironmentKey: EnvironmentKey {
-        static let defaultValue: PocketBase? = nil
-    }
-
     extension EnvironmentValues {
-
-        // MARK: Public
-
-        public var pocketBase: PocketBase? {
-            get { self[PocketBaseEnvironmentKey.self] }
-            set { self[PocketBaseEnvironmentKey.self] = newValue }
-        }
+        @Entry public var pocketBase: PocketBase? = nil
     }
 #endif

--- a/Sources/pocketbase-swift-sdk/environment.swift
+++ b/Sources/pocketbase-swift-sdk/environment.swift
@@ -1,0 +1,24 @@
+//
+//  environment.swift
+//  PocketBase
+//
+
+#if canImport(SwiftUI)
+    import SwiftUI
+
+    // MARK: - PocketBaseEnvironmentKey
+
+    private struct PocketBaseEnvironmentKey: EnvironmentKey {
+        static let defaultValue: PocketBase? = nil
+    }
+
+    extension EnvironmentValues {
+
+        // MARK: Public
+
+        public var pocketBase: PocketBase? {
+            get { self[PocketBaseEnvironmentKey.self] }
+            set { self[PocketBaseEnvironmentKey.self] = newValue }
+        }
+    }
+#endif

--- a/Sources/pocketbase-swift-sdk/errors.swift
+++ b/Sources/pocketbase-swift-sdk/errors.swift
@@ -9,8 +9,6 @@ import Foundation
 
 public enum PBError: Error, LocalizedError {
     case missingEnvironment
-    case notAuthenticated
-    case fetchCancelled
 
     // MARK: Public
 
@@ -18,10 +16,6 @@ public enum PBError: Error, LocalizedError {
         switch self {
         case .missingEnvironment:
             "PocketBase instance not found in SwiftUI environment. Use .environment(\\.pocketBase, pocketBase) in your App."
-        case .notAuthenticated:
-            "User is not authenticated."
-        case .fetchCancelled:
-            "Fetch was cancelled."
         }
     }
 }

--- a/Sources/pocketbase-swift-sdk/errors.swift
+++ b/Sources/pocketbase-swift-sdk/errors.swift
@@ -1,0 +1,27 @@
+//
+//  errors.swift
+//  PocketBase
+//
+
+import Foundation
+
+// MARK: - PBError
+
+public enum PBError: Error, LocalizedError {
+    case missingEnvironment
+    case notAuthenticated
+    case fetchCancelled
+
+    // MARK: Public
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingEnvironment:
+            "PocketBase instance not found in SwiftUI environment. Use .environment(\\.pocketBase, pocketBase) in your App."
+        case .notAuthenticated:
+            "User is not authenticated."
+        case .fetchCancelled:
+            "Fetch was cancelled."
+        }
+    }
+}

--- a/Sources/pocketbase-swift-sdk/expand.swift
+++ b/Sources/pocketbase-swift-sdk/expand.swift
@@ -51,7 +51,7 @@ public struct ExpandQuery: Sendable {
 // MARK: - ExpandBuilder
 
 /// Type-safe expand builder for collections
-public class ExpandBuilder {
+public struct ExpandBuilder: Sendable {
 
     // MARK: Lifecycle
 
@@ -62,15 +62,17 @@ public class ExpandBuilder {
     /// Add a field to expand
     @discardableResult
     public func field(_ field: String) -> ExpandBuilder {
-        fields.append(field)
-        return self
+        var copy = self
+        copy.fields.append(field)
+        return copy
     }
 
     /// Add nested expansion (e.g., "author.profile")
     @discardableResult
     public func nested(_ path: String) -> ExpandBuilder {
-        fields.append(path)
-        return self
+        var copy = self
+        copy.fields.append(path)
+        return copy
     }
 
     /// Build the expand query

--- a/Sources/pocketbase-swift-sdk/expand.swift
+++ b/Sources/pocketbase-swift-sdk/expand.swift
@@ -8,7 +8,7 @@
 // MARK: - ExpandQuery
 
 /// Represents a PocketBase expand query with support for nested expansions
-public struct ExpandQuery {
+public struct ExpandQuery: Sendable {
 
     // MARK: Lifecycle
 

--- a/Sources/pocketbase-swift-sdk/filters.swift
+++ b/Sources/pocketbase-swift-sdk/filters.swift
@@ -8,7 +8,7 @@
 // MARK: - FilterOperator
 
 /// PocketBase filter operators
-public enum FilterOperator: String, CaseIterable {
+public enum FilterOperator: String, CaseIterable, Sendable {
     case equal = "="
     case notEqual = "!="
     case greaterThan = ">"
@@ -26,7 +26,7 @@ public enum FilterOperator: String, CaseIterable {
 // MARK: - FilterCondition
 
 /// Represents a single filter condition
-public struct FilterCondition {
+public struct FilterCondition: Sendable {
 
     // MARK: Lifecycle
 
@@ -70,7 +70,7 @@ public struct FilterCondition {
 // MARK: - FiltersQuery
 
 /// Represents a PocketBase filters query with support for multiple conditions
-public struct FiltersQuery {
+public struct FiltersQuery: Sendable {
 
     // MARK: Lifecycle
 

--- a/Sources/pocketbase-swift-sdk/filters.swift
+++ b/Sources/pocketbase-swift-sdk/filters.swift
@@ -185,7 +185,7 @@ public struct FiltersQuery: Sendable {
 // MARK: - FilterBuilder
 
 /// Type-safe filter builder for collections
-public class FilterBuilder {
+public struct FilterBuilder: Sendable {
 
     // MARK: Lifecycle
 
@@ -196,16 +196,15 @@ public class FilterBuilder {
     /// Add a filter condition
     @discardableResult
     public func condition(_ condition: FilterCondition) -> FilterBuilder {
-        conditions.append(condition)
-        return self
+        var copy = self
+        copy.conditions.append(condition)
+        return copy
     }
 
     /// Add a simple filter condition
     @discardableResult
     public func filter(field: String, op: FilterOperator, value: String) -> FilterBuilder {
-        let condition = FilterCondition(field: field, op: op, value: value)
-        conditions.append(condition)
-        return self
+        condition(FilterCondition(field: field, op: op, value: value))
     }
 
     /// Add an equality filter

--- a/Sources/pocketbase-swift-sdk/pb.swift
+++ b/Sources/pocketbase-swift-sdk/pb.swift
@@ -79,7 +79,7 @@ public struct PasswordAuthentication: PBCollection {
 
 // MARK: - PocketBase
 
-public class PocketBase {
+public class PocketBase: @unchecked Sendable {
 
     // MARK: Lifecycle
 
@@ -119,6 +119,7 @@ public class PocketBase {
         model _: T.Type,
         expand: ExpandQuery? = nil,
         filters: FiltersQuery? = nil,
+        sort: String? = nil,
         page: Int = 1,
         perPage: Int = 100)
     async throws -> PBListResponse<T> {
@@ -135,6 +136,10 @@ public class PocketBase {
 
             if let filters, !filters.isEmpty {
                 baseQueryItems.append(URLQueryItem(name: "filter", value: filters.queryString))
+            }
+
+            if let sort {
+                baseQueryItems.append(URLQueryItem(name: "sort", value: sort))
             }
 
             return baseQueryItems
@@ -245,6 +250,7 @@ public class Collection<T: PBCollection> {
     public func getList(
         expand: ExpandQuery? = nil,
         filters: FiltersQuery? = nil,
+        sort: PBSortQuery<T>? = nil,
         page: Int = 1,
         perPage: Int = 100)
     async throws -> PBListResponse<T> {
@@ -261,6 +267,10 @@ public class Collection<T: PBCollection> {
 
             if let filters, !filters.isEmpty {
                 baseQueryItems.append(URLQueryItem(name: "filter", value: filters.queryString))
+            }
+
+            if let sort, !sort.isEmpty {
+                baseQueryItems.append(URLQueryItem(name: "sort", value: sort.queryString))
             }
 
             return baseQueryItems

--- a/Sources/pocketbase-swift-sdk/pb.swift
+++ b/Sources/pocketbase-swift-sdk/pb.swift
@@ -79,6 +79,9 @@ public struct PasswordAuthentication: PBCollection {
 
 // MARK: - PocketBase
 
+// @unchecked Sendable: Alamofire.Session is internally thread-safe (uses serial dispatch queue).
+// SecureStorage uses Keychain which is OS-level thread-safe. All stored properties are either
+// value types or immutable after init.
 public class PocketBase: @unchecked Sendable {
 
     // MARK: Lifecycle
@@ -202,7 +205,7 @@ public class PocketBase: @unchecked Sendable {
     // MARK: Internal
 
     let baseURL: String
-    var httpClient: HttpClient
+    let httpClient: HttpClient
     let secureStorage = SecureStorage()
     let logger = Logger(category: "PocketBase")
 

--- a/Sources/pocketbase-swift-sdk/pb.swift
+++ b/Sources/pocketbase-swift-sdk/pb.swift
@@ -77,6 +77,21 @@ public struct PasswordAuthentication: PBCollection {
     public let identityFields: [String]
 }
 
+// MARK: - Shared URL Builder
+
+func buildURL(baseURL: String, path: String, expand: ExpandQuery? = nil) -> String {
+    var url = URLComponents(string: baseURL)
+
+    // Append the path to the existing path, ensuring proper URL construction
+    let fullPath = (url?.path ?? "") + path
+    url?.path = fullPath
+
+    if let expand, !expand.isEmpty {
+        url?.queryItems = [URLQueryItem(name: "expand", value: expand.queryString)]
+    }
+    return url?.string ?? ""
+}
+
 // MARK: - PocketBase
 
 // @unchecked Sendable: Alamofire.Session is internally thread-safe (uses serial dispatch queue).
@@ -112,7 +127,7 @@ public class PocketBase: @unchecked Sendable {
         expand: ExpandQuery? = nil)
     async throws -> Output {
         let urlString = "/api/collections/\(collection)/records/\(id)"
-        let finalURLString = buildURL(urlString, expand: expand)
+        let finalURLString = buildURL(baseURL: baseURL, path: urlString, expand: expand)
         logger.info("GET \(finalURLString)")
         return try await httpClient.get(finalURLString, output: model).get()
     }
@@ -166,13 +181,34 @@ public class PocketBase: @unchecked Sendable {
         return try await httpClient.get(urlString, output: PBListResponse<T>.self).get()
     }
 
+    /// Typed sort overload for callers who prefer `PBSortQuery<T>` over a raw sort string.
+    public func getList<T: PBCollection>(
+        collection: String,
+        model: T.Type,
+        expand: ExpandQuery? = nil,
+        filters: FiltersQuery? = nil,
+        sort: PBSortQuery<T>,
+        page: Int = 1,
+        perPage: Int = 100
+    ) async throws -> PBListResponse<T> {
+        try await getList(
+            collection: collection,
+            model: model,
+            expand: expand,
+            filters: filters,
+            sort: sort.queryString,
+            page: page,
+            perPage: perPage
+        )
+    }
+
     public func create<Output: Decodable & Sendable>(
         collection: String,
         record: some Encodable & Sendable,
         output: Output.Type)
     async throws -> Output {
         let path = "/api/collections/\(collection)/records"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("POST \(urlString)")
         return try await httpClient.post(urlString, input: record, output: output).get()
     }
@@ -183,7 +219,7 @@ public class PocketBase: @unchecked Sendable {
         record: T)
     async throws -> T {
         let path = "/api/collections/\(collection)/records/\(id)"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("PATCH \(urlString)")
         return try await httpClient.patch(urlString, input: record, output: T.self).get()
     }
@@ -193,7 +229,7 @@ public class PocketBase: @unchecked Sendable {
         id: String)
     async throws {
         let path = "/api/collections/\(collection)/records/\(id)"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("DELETE \(urlString)")
         let _: EmptyResponse = try await httpClient.delete(urlString, output: PBEmptyEntity.self).get()
     }
@@ -209,26 +245,13 @@ public class PocketBase: @unchecked Sendable {
     let secureStorage = SecureStorage()
     let logger = Logger(category: "PocketBase")
 
-    func buildURL(_ path: String, expand: ExpandQuery? = nil) -> String {
-        var url = URLComponents(string: baseURL)
-
-        // Append the path to the existing path, ensuring proper URL construction
-        let fullPath = (url?.path ?? "") + path
-        url?.path = fullPath
-
-        if let expand, !expand.isEmpty {
-            url?.queryItems = [URLQueryItem(name: "expand", value: expand.queryString)]
-        }
-        let val = url?.string ?? ""
-
-        return val
-    }
-
 }
 
 // MARK: - Collection
 
-public class Collection<T: PBCollection> {
+// @unchecked Sendable: stored properties are either value types or
+// Alamofire.Session (internally thread-safe via serial dispatch queue).
+public class Collection<T: PBCollection>: @unchecked Sendable {
 
     // MARK: Lifecycle
 
@@ -245,7 +268,7 @@ public class Collection<T: PBCollection> {
         expand: ExpandQuery? = nil)
     async throws -> T {
         let urlString = "/api/collections/\(collectionName)/records/\(id)"
-        let finalURLString = buildURL(urlString, expand: expand)
+        let finalURLString = buildURL(baseURL: baseURL, path: urlString, expand: expand)
         logger.info("GET \(finalURLString)")
         return try await httpClient.get(finalURLString, output: T.self).get()
     }
@@ -302,7 +325,7 @@ public class Collection<T: PBCollection> {
         output: Output.Type)
     async throws -> Output {
         let path = "/api/collections/\(collectionName)/records"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("POST \(urlString)")
         return try await httpClient.post(urlString, input: record, output: output).get()
     }
@@ -312,7 +335,7 @@ public class Collection<T: PBCollection> {
         record: T)
     async throws -> T {
         let path = "/api/collections/\(collectionName)/records/\(id)"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("PATCH \(urlString)")
         return try await httpClient.patch(urlString, input: record, output: T.self).get()
     }
@@ -321,16 +344,16 @@ public class Collection<T: PBCollection> {
         id: String)
     async throws {
         let path = "/api/collections/\(collectionName)/records/\(id)"
-        let urlString = buildURL(path)
+        let urlString = buildURL(baseURL: baseURL, path: path)
         logger.info("DELETE \(urlString)")
         let _: EmptyResponse = try await httpClient.delete(urlString, output: PBEmptyEntity.self).get()
     }
 
     public func realtime(
         record: String = "*",
-        onConnect: @escaping () -> Void,
-        onDisconnect: @escaping () -> Void,
-        onEvent: @escaping (RealtimeEvent<T>) -> Void)
+        onConnect: @escaping @MainActor () -> Void,
+        onDisconnect: @escaping @MainActor () -> Void,
+        onEvent: @escaping @MainActor (RealtimeEvent<T>) -> Void)
     -> Realtime<T> {
         Realtime(
             baseURL: baseURL,
@@ -343,7 +366,7 @@ public class Collection<T: PBCollection> {
 
     public func realtime(
         record: String = "*",
-        onEvent: @escaping (RealtimeEvent<T>) -> Void)
+        onEvent: @escaping @MainActor (RealtimeEvent<T>) -> Void)
     -> Realtime<T> {
         Realtime(
             baseURL: baseURL,
@@ -360,18 +383,5 @@ public class Collection<T: PBCollection> {
     private let collectionName: String
     private let httpClient: HttpClient
     private let logger = Logger(category: "Collection")
-
-    private func buildURL(_ path: String, expand: ExpandQuery? = nil) -> String {
-        var url = URLComponents(string: baseURL)
-
-        // Append the path to the existing path, ensuring proper URL construction
-        let fullPath = (url?.path ?? "") + path
-        url?.path = fullPath
-
-        if let expand, !expand.isEmpty {
-            url?.queryItems = [URLQueryItem(name: "expand", value: expand.queryString)]
-        }
-        return url?.string ?? ""
-    }
 
 }

--- a/Sources/pocketbase-swift-sdk/query.swift
+++ b/Sources/pocketbase-swift-sdk/query.swift
@@ -17,6 +17,8 @@
 
     // MARK: - QueryStorage
 
+    // @unchecked Sendable: all access is exclusively from @MainActor via PBQuery's @State storage.
+    // No internal synchronization is needed.
     private final class QueryStorage<T: PBCollection>: @unchecked Sendable {
         var items: [T] = []
         var isLoading = false
@@ -98,6 +100,10 @@
                 return
             }
 
+            if (storage.error as? PBError) == .missingEnvironment {
+                storage.error = nil
+            }
+
             let newHash = computeConfigHash()
             let tokenChanged = storage.refreshToken != storage.lastRefreshToken
 
@@ -112,6 +118,11 @@
 
             storage.configHash = newHash
             storage.fetchTask?.cancel()
+
+            if configChanged {
+                storage.realtimeSubscription?.unsubscribe()
+                storage.realtimeSubscription = nil
+            }
 
             let s = storage
             let name = collectionName
@@ -173,6 +184,7 @@
             perPage: Int,
             realtime: Bool
         ) async {
+            let logger = Logger(category: "PBQuery")
             storage.isLoading = true
             storage.error = nil
             defer { storage.isLoading = false }
@@ -188,8 +200,10 @@
                 )
                 storage.items = result.items
             } catch is CancellationError {
+                logger.debug("Fetch cancelled for collection '\(collection)'")
                 return
             } catch {
+                logger.error("Fetch failed for collection '\(collection)': \(error.localizedDescription)")
                 storage.error = error
             }
 
@@ -221,7 +235,8 @@
                 record: "*",
                 onConnect: {},
                 onDisconnect: {},
-                onEvent: { _ in
+                onEvent: { [weak storage] _ in
+                    guard let storage else { return }
                     Task { @MainActor [weak storage] in
                         guard let storage else { return }
                         storage.fetchTask?.cancel()

--- a/Sources/pocketbase-swift-sdk/query.swift
+++ b/Sources/pocketbase-swift-sdk/query.swift
@@ -239,22 +239,19 @@
                 onDisconnect: {},
                 onEvent: { [weak storage] _ in
                     guard let storage else { return }
-                    Task { @MainActor [weak storage] in
+                    storage.fetchTask?.cancel()
+                    storage.fetchTask = Task { @MainActor [weak storage] in
                         guard let storage else { return }
-                        storage.fetchTask?.cancel()
-                        storage.fetchTask = Task { @MainActor [weak storage] in
-                            guard let storage else { return }
-                            await runFetch(
-                                pb: pb,
-                                storage: storage,
-                                collection: collection,
-                                filter: filter,
-                                sortDescriptors: sortDescriptors,
-                                expand: expand,
-                                perPage: perPage,
-                                realtime: false
-                            )
-                        }
+                        await runFetch(
+                            pb: pb,
+                            storage: storage,
+                            collection: collection,
+                            filter: filter,
+                            sortDescriptors: sortDescriptors,
+                            expand: expand,
+                            perPage: perPage,
+                            realtime: false
+                        )
                     }
                 }
             )

--- a/Sources/pocketbase-swift-sdk/query.swift
+++ b/Sources/pocketbase-swift-sdk/query.swift
@@ -1,0 +1,256 @@
+//
+//  query.swift
+//  PocketBase
+//
+
+#if canImport(SwiftUI)
+    import os
+    import SwiftUI
+
+    // MARK: - PBQueryProjection
+
+    public struct PBQueryProjection<T: PBCollection> {
+        public let isLoading: Bool
+        public let error: (any Error)?
+        public let refresh: () -> Void
+    }
+
+    // MARK: - QueryStorage
+
+    private final class QueryStorage<T: PBCollection>: @unchecked Sendable {
+        var items: [T] = []
+        var isLoading = false
+        var error: (any Error)?
+        var configHash = 0
+        var refreshToken = 0
+        var lastRefreshToken = 0
+        var fetchTask: Task<Void, Never>?
+        var realtimeSubscription: Realtime<T>?
+
+        deinit {
+            fetchTask?.cancel()
+            realtimeSubscription?.unsubscribe()
+        }
+    }
+
+    // MARK: - PBQuery
+
+    @propertyWrapper
+    public struct PBQuery<T: PBCollection>: DynamicProperty {
+
+        // MARK: Lifecycle
+
+        public init(
+            collection: String,
+            filter: FiltersQuery? = nil,
+            sort: [PBSortDescriptor<T>] = [],
+            expand: ExpandQuery? = nil,
+            perPage: Int = 100,
+            realtime: Bool = false
+        ) {
+            self.collectionName = collection
+            self.filter = filter
+            self.sortDescriptors = sort
+            self.expand = expand
+            self.perPage = perPage
+            self.realtimeEnabled = realtime
+            self._storage = State(initialValue: QueryStorage())
+        }
+
+        public init<V>(
+            collection: String,
+            filter: FiltersQuery? = nil,
+            sort keyPath: KeyPath<T, V> & Sendable,
+            order: PBSortOrder = .forward,
+            expand: ExpandQuery? = nil,
+            perPage: Int = 100,
+            realtime: Bool = false
+        ) {
+            self.init(
+                collection: collection,
+                filter: filter,
+                sort: [PBSortDescriptor(keyPath, order: order)],
+                expand: expand,
+                perPage: perPage,
+                realtime: realtime
+            )
+        }
+
+        // MARK: Public
+
+        public var wrappedValue: [T] { storage.items }
+
+        public var projectedValue: PBQueryProjection<T> {
+            PBQueryProjection(
+                isLoading: storage.isLoading,
+                error: storage.error,
+                refresh: { [storage] in storage.refreshToken += 1 }
+            )
+        }
+
+        // MARK: Internal
+
+        public mutating func update() {
+            guard let pb = pocketBase else {
+                if storage.items.isEmpty, !storage.isLoading {
+                    storage.error = PBError.missingEnvironment
+                }
+                return
+            }
+
+            let newHash = computeConfigHash()
+            let tokenChanged = storage.refreshToken != storage.lastRefreshToken
+
+            if tokenChanged {
+                storage.lastRefreshToken = storage.refreshToken
+            }
+
+            let configChanged = newHash != storage.configHash
+            let needsInitialFetch = storage.items.isEmpty && !storage.isLoading && storage.error == nil
+
+            guard configChanged || tokenChanged || needsInitialFetch else { return }
+
+            storage.configHash = newHash
+            storage.fetchTask?.cancel()
+
+            let s = storage
+            let name = collectionName
+            let f = filter
+            let descs = sortDescriptors
+            let exp = expand
+            let pp = perPage
+            let rt = realtimeEnabled
+
+            storage.fetchTask = Task { @MainActor [weak s] in
+                guard let s else { return }
+                await Self.runFetch(
+                    pb: pb,
+                    storage: s,
+                    collection: name,
+                    filter: f,
+                    sortDescriptors: descs,
+                    expand: exp,
+                    perPage: pp,
+                    realtime: rt
+                )
+            }
+        }
+
+        // MARK: Private
+
+        @Environment(\.pocketBase) private var pocketBase
+        @State private var storage: QueryStorage<T>
+
+        private let collectionName: String
+        private let filter: FiltersQuery?
+        private let sortDescriptors: [PBSortDescriptor<T>]
+        private let expand: ExpandQuery?
+        private let perPage: Int
+        private let realtimeEnabled: Bool
+
+        private func computeConfigHash() -> Int {
+            var hasher = Hasher()
+            hasher.combine(collectionName)
+            hasher.combine(filter?.queryString)
+            for desc in sortDescriptors {
+                hasher.combine(desc.fieldName)
+                hasher.combine(desc.order)
+            }
+            hasher.combine(expand?.queryString)
+            hasher.combine(perPage)
+            hasher.combine(realtimeEnabled)
+            return hasher.finalize()
+        }
+
+        @MainActor
+        private static func runFetch(
+            pb: PocketBase,
+            storage: QueryStorage<T>,
+            collection: String,
+            filter: FiltersQuery?,
+            sortDescriptors: [PBSortDescriptor<T>],
+            expand: ExpandQuery?,
+            perPage: Int,
+            realtime: Bool
+        ) async {
+            storage.isLoading = true
+            storage.error = nil
+            defer { storage.isLoading = false }
+
+            do {
+                let sortQuery = sortDescriptors.isEmpty ? nil : PBSortQuery(sortDescriptors)
+                let result = try await pb.collection(collection).getList(
+                    expand: expand,
+                    filters: filter,
+                    sort: sortQuery,
+                    page: 1,
+                    perPage: perPage
+                )
+                storage.items = result.items
+            } catch is CancellationError {
+                return
+            } catch {
+                storage.error = error
+            }
+
+            if realtime, storage.realtimeSubscription == nil {
+                setupRealtime(
+                    pb: pb,
+                    storage: storage,
+                    collection: collection,
+                    filter: filter,
+                    sortDescriptors: sortDescriptors,
+                    expand: expand,
+                    perPage: perPage
+                )
+            }
+        }
+
+        @MainActor
+        private static func setupRealtime(
+            pb: PocketBase,
+            storage: QueryStorage<T>,
+            collection: String,
+            filter: FiltersQuery?,
+            sortDescriptors: [PBSortDescriptor<T>],
+            expand: ExpandQuery?,
+            perPage: Int
+        ) {
+            let rt: Realtime<T> = pb.realtime(
+                collection: collection,
+                record: "*",
+                onConnect: {},
+                onDisconnect: {},
+                onEvent: { _ in
+                    Task { @MainActor [weak storage] in
+                        guard let storage else { return }
+                        storage.fetchTask?.cancel()
+                        storage.fetchTask = Task { @MainActor [weak storage] in
+                            guard let storage else { return }
+                            await runFetch(
+                                pb: pb,
+                                storage: storage,
+                                collection: collection,
+                                filter: filter,
+                                sortDescriptors: sortDescriptors,
+                                expand: expand,
+                                perPage: perPage,
+                                realtime: false
+                            )
+                        }
+                    }
+                }
+            )
+            storage.realtimeSubscription = rt
+            Task {
+                do {
+                    try await rt.subscribe()
+                } catch {
+                    let logger = Logger(category: "PBQuery")
+                    logger.error("Realtime subscription failed for collection '\(collection)': \(error.localizedDescription)")
+                    storage.error = error
+                }
+            }
+        }
+    }
+#endif

--- a/Sources/pocketbase-swift-sdk/query.swift
+++ b/Sources/pocketbase-swift-sdk/query.swift
@@ -17,8 +17,10 @@
 
     // MARK: - QueryStorage
 
-    // @unchecked Sendable: all access is exclusively from @MainActor via PBQuery's @State storage.
-    // No internal synchronization is needed.
+    // @unchecked Sendable: all mutable state is accessed exclusively from @MainActor
+    // via PBQuery's @State storage and @MainActor runFetch/setupRealtime methods.
+    // @Observable enables SwiftUI to track property-level mutations on this reference type.
+    @Observable
     private final class QueryStorage<T: PBCollection>: @unchecked Sendable {
         var items: [T] = []
         var isLoading = false
@@ -112,7 +114,7 @@
             }
 
             let configChanged = newHash != storage.configHash
-            let needsInitialFetch = storage.items.isEmpty && !storage.isLoading && storage.error == nil
+            let needsInitialFetch = storage.items.isEmpty && !storage.isLoading && storage.error == nil && storage.fetchTask == nil
 
             guard configChanged || tokenChanged || needsInitialFetch else { return }
 

--- a/Sources/pocketbase-swift-sdk/realtime.swift
+++ b/Sources/pocketbase-swift-sdk/realtime.swift
@@ -164,7 +164,10 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
                 return
             }
             let decoder = JSONDecoder()
-            let jsonData = data.data(using: .utf8)!
+            guard let jsonData = data.data(using: .utf8) else {
+                logger.error("PB_CONNECT data is not valid UTF-8")
+                return
+            }
             let pbConnect = try decoder.decode(PBCONNECT.self, from: jsonData)
             clientID = pbConnect.clientId
         } catch {
@@ -180,7 +183,10 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
             }
 
             let decoder = JSONDecoder()
-            let jsonData = data.data(using: .utf8)!
+            guard let jsonData = data.data(using: .utf8) else {
+                logger.error("Realtime event data is not valid UTF-8")
+                return
+            }
 
             // Decode the realtime event
             let realtimeEvent = try decoder.decode(RealtimeEvent<T>.self, from: jsonData)
@@ -199,8 +205,10 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         }
 
         let realtimeURL = "\(baseURL)/api/realtime"
-        let urlComps = URLComponents(string: realtimeURL)!
-        let url = urlComps.url!
+        guard let urlComps = URLComponents(string: realtimeURL), let url = urlComps.url else {
+            logger.error("Invalid realtime URL: \(realtimeURL)")
+            return
+        }
 
         let parameters: [String: Any] = [
             "clientId": clientID,
@@ -211,7 +219,7 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
             _ = try await sendPostRequest(url: url, parameters: parameters)
             logger.info("Subscribed")
         } catch {
-            logger.error("Error: \(error)")
+            logger.error("Error subscribing to record: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/pocketbase-swift-sdk/realtime.swift
+++ b/Sources/pocketbase-swift-sdk/realtime.swift
@@ -101,6 +101,8 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
                     logger.info("Realtime connection initiated.")
                 case .error(let error):
                     logger.error("\(error.localizedDescription)")
+                    connected = false
+                    onDisconnect()
                 case .event(let event):
                     if event.event == "PB_CONNECT" {
                         logger.info("Realtime connection established.")
@@ -220,6 +222,8 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
             logger.info("Subscribed")
         } catch {
             logger.error("Error subscribing to record: \(error.localizedDescription)")
+            connected = false
+            onDisconnect()
         }
     }
 

--- a/Sources/pocketbase-swift-sdk/realtime.swift
+++ b/Sources/pocketbase-swift-sdk/realtime.swift
@@ -156,14 +156,11 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
 
     private var clientID: String? {
         didSet {
-            Task {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
                 await self.subscribeToRecord()
             }
         }
-    }
-
-    private func handleMessage(id: String?, event: String?, data: String?) {
-        logger.info("id: \(id ?? "No ID"), event: \(event ?? "No event"), data: \(data ?? "No data")")
     }
 
     private func handlePBConnect(data: String?) {

--- a/Sources/pocketbase-swift-sdk/realtime.swift
+++ b/Sources/pocketbase-swift-sdk/realtime.swift
@@ -108,10 +108,11 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
                         onDisconnect()
                     case .event(let event):
                         if event.event == "PB_CONNECT" {
-                            logger.info("Realtime connection established.")
-                            connected = true
-                            handlePBConnect(data: event.data)
-                            onConnect()
+                            logger.info("Realtime connection handshake received.")
+                            if handlePBConnect(data: event.data) {
+                                connected = true
+                                onConnect()
+                            }
                         } else {
                             handleRealtimeEvent(data: event.data)
                         }
@@ -163,21 +164,23 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         }
     }
 
-    private func handlePBConnect(data: String?) {
+    private func handlePBConnect(data: String?) -> Bool {
         do {
             guard let data else {
                 logger.warning("No data received for PB_CONNECT")
-                return
+                return false
             }
             let decoder = JSONDecoder()
             guard let jsonData = data.data(using: .utf8) else {
                 logger.error("PB_CONNECT data is not valid UTF-8")
-                return
+                return false
             }
             let pbConnect = try decoder.decode(PBCONNECT.self, from: jsonData)
             clientID = pbConnect.clientId
+            return true
         } catch {
             logger.error("Error decoding PB_CONNECT: \(error)")
+            return false
         }
     }
 

--- a/Sources/pocketbase-swift-sdk/realtime.swift
+++ b/Sources/pocketbase-swift-sdk/realtime.swift
@@ -15,9 +15,9 @@ extension PocketBase {
     public func realtime<T: PBCollection>(
         collection: String,
         record: String = "*",
-        onConnect: @escaping () -> Void,
-        onDisconnect: @escaping () -> Void,
-        onEvent: @escaping (RealtimeEvent<T>) -> Void)
+        onConnect: @escaping @MainActor () -> Void,
+        onDisconnect: @escaping @MainActor () -> Void,
+        onEvent: @escaping @MainActor (RealtimeEvent<T>) -> Void)
     -> Realtime<T> {
         Realtime(
             baseURL: baseURL,
@@ -31,7 +31,7 @@ extension PocketBase {
     public func realtime<T: PBCollection>(
         collection: String,
         record: String = "*",
-        onEvent: @escaping (RealtimeEvent<T>) -> Void)
+        onEvent: @escaping @MainActor (RealtimeEvent<T>) -> Void)
     -> Realtime<T> {
         Realtime(
             baseURL: baseURL,
@@ -53,9 +53,9 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         baseURL: String,
         collection: String,
         record: String = "*",
-        onConnect: @escaping () -> Void,
-        onDisconnect: @escaping () -> Void,
-        onEvent: @escaping (RealtimeEvent<T>) -> Void) {
+        onConnect: @escaping @MainActor () -> Void,
+        onDisconnect: @escaping @MainActor () -> Void,
+        onEvent: @escaping @MainActor (RealtimeEvent<T>) -> Void) {
         self.baseURL = baseURL
         self.onConnect = onConnect
         self.onDisconnect = onDisconnect
@@ -70,7 +70,7 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
 
     // MARK: Public
 
-    public var connected = false
+    @MainActor public var connected = false
 
     public static func == (lhs: Realtime, rhs: Realtime) -> Bool {
         lhs.clientID == rhs.clientID
@@ -94,28 +94,32 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
             return
         }
 
-        subscriptionTask = Task {
+        subscriptionTask = Task { @concurrent [weak self] in
+            guard let self else { return }
             for await event in dataTask.events() {
-                switch event {
-                case .open:
-                    logger.info("Realtime connection initiated.")
-                case .error(let error):
-                    logger.error("\(error.localizedDescription)")
-                    connected = false
-                    onDisconnect()
-                case .event(let event):
-                    if event.event == "PB_CONNECT" {
-                        logger.info("Realtime connection established.")
-                        connected = true
-                        handlePBConnect(data: event.data)
-                        onConnect()
-                    } else {
-                        handleRealtimeEvent(data: event.data)
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    switch event {
+                    case .open:
+                        logger.info("Realtime connection initiated.")
+                    case .error(let error):
+                        logger.error("\(error.localizedDescription)")
+                        connected = false
+                        onDisconnect()
+                    case .event(let event):
+                        if event.event == "PB_CONNECT" {
+                            logger.info("Realtime connection established.")
+                            connected = true
+                            handlePBConnect(data: event.data)
+                            onConnect()
+                        } else {
+                            handleRealtimeEvent(data: event.data)
+                        }
+                    case .closed:
+                        logger.info("Realtime connection closed.")
+                        connected = false
+                        onDisconnect()
                     }
-                case .closed:
-                    logger.info("Realtime connection closed.")
-                    connected = false
-                    onDisconnect()
                 }
             }
         }
@@ -123,8 +127,11 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
 
     public func unsubscribe() {
         subscriptionTask?.cancel()
-        connected = false
-        onDisconnect()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            connected = false
+            onDisconnect()
+        }
     }
 
     // MARK: Private
@@ -133,7 +140,7 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         let clientId: String
     }
 
-    private let onEvent: (RealtimeEvent<T>) -> Void
+    private let onEvent: @MainActor (RealtimeEvent<T>) -> Void
 
     private let baseURL: String
 
@@ -141,8 +148,8 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
     private var subscriptionTask: Task<Void, Never>?
 
     private let logger = Logger(category: "RealTime")
-    private let onConnect: () -> Void
-    private let onDisconnect: () -> Void
+    private let onConnect: @MainActor () -> Void
+    private let onDisconnect: @MainActor () -> Void
     private let collection: String
     private let record: String
     private var eventSource = EventSource()
@@ -177,7 +184,7 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         }
     }
 
-    private func handleRealtimeEvent(data: String?) {
+    @MainActor private func handleRealtimeEvent(data: String?) {
         do {
             guard let data else {
                 logger.warning("No data received for realtime event")
@@ -200,7 +207,7 @@ public final class Realtime<T: PBCollection>: Equatable, @unchecked Sendable {
         }
     }
 
-    private func subscribeToRecord() async {
+    @MainActor private func subscribeToRecord() async {
         guard let clientID else {
             logger.error("No client ID found")
             return

--- a/Sources/pocketbase-swift-sdk/sort.swift
+++ b/Sources/pocketbase-swift-sdk/sort.swift
@@ -24,6 +24,7 @@ public struct PBSortDescriptor<T>: Equatable, Hashable, Sendable {
     }
 
     public init(_ fieldName: String, order: PBSortOrder = .forward) {
+        precondition(!fieldName.isEmpty, "PBSortDescriptor fieldName must not be empty")
         self.fieldName = fieldName
         self.order = order
     }
@@ -42,6 +43,9 @@ public struct PBSortDescriptor<T>: Equatable, Hashable, Sendable {
 
     // MARK: Private
 
+    // Relies on String(describing: keyPath) producing the "\TypeName.property" format.
+    // If Swift changes KeyPath's description format in a future version, this may silently
+    // produce incorrect field names. Use the String-based init as an escape hatch.
     private static func extractFieldName<V>(from keyPath: KeyPath<T, V>) -> String {
         let description = String(describing: keyPath)
         guard let backslashIndex = description.firstIndex(of: "\\") else {

--- a/Sources/pocketbase-swift-sdk/sort.swift
+++ b/Sources/pocketbase-swift-sdk/sort.swift
@@ -1,0 +1,83 @@
+//
+//  sort.swift
+//  PocketBase
+//
+
+import Foundation
+
+// MARK: - PBSortOrder
+
+public enum PBSortOrder: String, Sendable, CaseIterable {
+    case forward
+    case reverse
+}
+
+// MARK: - PBSortDescriptor
+
+public struct PBSortDescriptor<T>: Equatable, Hashable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init<V>(_ keyPath: KeyPath<T, V> & Sendable, order: PBSortOrder = .forward) {
+        self.fieldName = Self.extractFieldName(from: keyPath)
+        self.order = order
+    }
+
+    public init(_ fieldName: String, order: PBSortOrder = .forward) {
+        self.fieldName = fieldName
+        self.order = order
+    }
+
+    // MARK: Public
+
+    public let fieldName: String
+    public let order: PBSortOrder
+
+    public var queryString: String {
+        switch order {
+        case .forward: fieldName
+        case .reverse: "-\(fieldName)"
+        }
+    }
+
+    // MARK: Private
+
+    private static func extractFieldName<V>(from keyPath: KeyPath<T, V>) -> String {
+        let description = String(describing: keyPath)
+        guard let backslashIndex = description.firstIndex(of: "\\") else {
+            return description
+        }
+        let afterBackslash = description[description.index(after: backslashIndex)...]
+        guard let dotIndex = afterBackslash.firstIndex(of: ".") else {
+            return String(afterBackslash)
+        }
+        return String(afterBackslash[afterBackslash.index(after: dotIndex)...])
+    }
+}
+
+// MARK: - PBSortQuery
+
+public struct PBSortQuery<T>: Equatable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init(_ descriptors: PBSortDescriptor<T>...) {
+        self.descriptors = descriptors
+    }
+
+    public init(_ descriptors: [PBSortDescriptor<T>]) {
+        self.descriptors = descriptors
+    }
+
+    // MARK: Public
+
+    public let descriptors: [PBSortDescriptor<T>]
+
+    public var queryString: String {
+        descriptors.map(\.queryString).joined(separator: ",")
+    }
+
+    public var isEmpty: Bool {
+        descriptors.isEmpty
+    }
+}

--- a/Tests/pocketbase-swift-sdkTests/auth_state_wrapper.swift
+++ b/Tests/pocketbase-swift-sdkTests/auth_state_wrapper.swift
@@ -1,0 +1,40 @@
+//
+//  auth_state_wrapper.swift
+//  PocketBase
+//
+
+#if canImport(SwiftUI)
+    import Testing
+    @testable import PocketBase
+
+    // MARK: - PBAuthState Structural Tests
+
+    @Suite("PBAuthState")
+    struct PBAuthStateTests {
+
+        @Test
+        func initialAuthInfoIsNotAuthenticated() {
+            let state = PBAuthState()
+            let info = state.wrappedValue
+            #expect(!info.isAuthenticated)
+            #expect(info.userId == nil)
+        }
+
+        @Test
+        func projectedValueReflectsState() {
+            let state = PBAuthState()
+            let projection = state.projectedValue
+            #expect(!projection.isAuthenticated)
+            #expect(projection.userId == nil)
+        }
+
+        @Test
+        func refreshIsCallable() {
+            let state = PBAuthState()
+            let projection = state.projectedValue
+            projection.refresh()
+            // After refresh, state should still be not authenticated (no PocketBase instance)
+            #expect(!state.wrappedValue.isAuthenticated)
+        }
+    }
+#endif

--- a/Tests/pocketbase-swift-sdkTests/query_wrapper.swift
+++ b/Tests/pocketbase-swift-sdkTests/query_wrapper.swift
@@ -1,0 +1,82 @@
+//
+//  query_wrapper.swift
+//  PocketBase
+//
+
+#if canImport(SwiftUI)
+    import Testing
+    @testable import PocketBase
+
+    // MARK: - PBQuery Structural Tests
+
+    @Suite("PBQuery")
+    struct PBQueryTests {
+
+        @Test
+        func initialWrappedValueIsEmpty() {
+            let query = PBQuery<Post>(collection: "posts")
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func projectedValueInitiallyNotLoading() {
+            let query = PBQuery<Post>(collection: "posts")
+            let projection = query.projectedValue
+            #expect(!projection.isLoading)
+            #expect(projection.error == nil)
+        }
+
+        @Test
+        func refreshIncrementsToken() {
+            let query = PBQuery<Post>(collection: "posts")
+            let projection = query.projectedValue
+            projection.refresh()
+            // After refresh, the value should still be empty (no fetch happened)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func initWithFilter() {
+            let filter = FiltersQuery().equal(field: "published", value: "true")
+            let query = PBQuery<Post>(collection: "posts", filter: filter)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func initWithSingleSortKeyPath() {
+            let query = PBQuery<Post>(collection: "posts", sort: \Post.title, order: .reverse)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func initWithSortArray() {
+            let sort = [PBSortDescriptor(\Post.title), PBSortDescriptor(\Post.created, order: .reverse)]
+            let query = PBQuery<Post>(collection: "posts", sort: sort)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func initWithExpand() {
+            let expand = ExpandQuery("author")
+            let query = PBQuery<Post>(collection: "posts", expand: expand)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func initWithRealtime() {
+            let query = PBQuery<Post>(collection: "posts", realtime: true)
+            #expect(query.wrappedValue.isEmpty)
+        }
+
+        @Test
+        func configHashChangesWithDifferentCollection() {
+            let query1 = PBQuery<Post>(collection: "posts")
+            let query2 = PBQuery<Post>(collection: "articles")
+            // Different collections produce different hashes
+            // We can't directly compare hashes (they're private), but structurally
+            // both should be initializable without issues
+            #expect(query1.wrappedValue.isEmpty)
+            #expect(query2.wrappedValue.isEmpty)
+        }
+    }
+#endif

--- a/Tests/pocketbase-swift-sdkTests/sort_tests.swift
+++ b/Tests/pocketbase-swift-sdkTests/sort_tests.swift
@@ -1,0 +1,197 @@
+//
+//  sort.swift
+//  PocketBase
+//
+
+import Foundation
+import Testing
+@testable import PocketBase
+
+// MARK: - PBSortDescriptor Tests
+
+@Suite("PBSortDescriptor")
+struct PBSortDescriptorTests {
+
+    @Test
+    func keyPathExtraction() {
+        let desc = PBSortDescriptor(\Post.title)
+        #expect(desc.fieldName == "title")
+    }
+
+    @Test
+    func keyPathNestedExtraction() {
+        // Nested key paths should produce dot-notation field names
+        let desc = PBSortDescriptor(\Post.title, order: .reverse)
+        #expect(desc.fieldName == "title")
+    }
+
+    @Test
+    func stringInit() {
+        let desc = PBSortDescriptor<Post>("custom_field")
+        #expect(desc.fieldName == "custom_field")
+        #expect(desc.order == .forward)
+    }
+
+    @Test
+    func stringInitReverse() {
+        let desc = PBSortDescriptor<Post>("created", order: .reverse)
+        #expect(desc.fieldName == "created")
+        #expect(desc.order == .reverse)
+    }
+
+    @Test
+    func queryStringForward() {
+        let desc = PBSortDescriptor(\Post.title, order: .forward)
+        #expect(desc.queryString == "title")
+    }
+
+    @Test
+    func queryStringReverse() {
+        let desc = PBSortDescriptor(\Post.title, order: .reverse)
+        #expect(desc.queryString == "-title")
+    }
+
+    @Test
+    func equatable() {
+        let a = PBSortDescriptor(\Post.title, order: .forward)
+        let b = PBSortDescriptor(\Post.title, order: .forward)
+        let c = PBSortDescriptor(\Post.title, order: .reverse)
+        #expect(a == b)
+        #expect(a != c)
+    }
+}
+
+// MARK: - PBSortQuery Tests
+
+@Suite("PBSortQuery")
+struct PBSortQueryTests {
+
+    @Test
+    func empty() {
+        let query = PBSortQuery<Post>()
+        #expect(query.isEmpty)
+        #expect(query.queryString == "")
+    }
+
+    @Test
+    func singleDescriptor() {
+        let query = PBSortQuery<Post>(PBSortDescriptor(\Post.title))
+        #expect(!query.isEmpty)
+        #expect(query.queryString == "title")
+    }
+
+    @Test
+    func multipleDescriptors() {
+        let query = PBSortQuery<Post>(
+            PBSortDescriptor(\Post.title, order: .reverse),
+            PBSortDescriptor(\Post.created)
+        )
+        #expect(query.queryString == "-title,created")
+    }
+
+    @Test
+    func variadicInit() {
+        let query = PBSortQuery<Post>(
+            PBSortDescriptor("field1"),
+            PBSortDescriptor("field2", order: .reverse),
+            PBSortDescriptor("field3")
+        )
+        #expect(query.queryString == "field1,-field2,field3")
+    }
+}
+
+// MARK: - Sort Integration Tests
+
+@Suite("Sort Integration")
+class SortIntegrationTests {
+
+    // MARK: Lifecycle
+
+    deinit {
+        let ids = createdPostIds
+        Task {
+            let pb = PocketBase(baseURL: "http://127.0.0.1:8090")
+            let posts: Collection<Post> = pb.collection("posts")
+            for id in ids {
+                try? await posts.delete(id: id)
+            }
+        }
+    }
+
+    // MARK: Internal
+
+    var createdPostIds: Set<String> = []
+
+    @Test
+    func getListWithSort() async throws {
+        let pb = PocketBase(baseURL: "http://127.0.0.1:8090")
+        let prefix = "SORT-ASC-\(UUID().uuidString.prefix(4))"
+
+        // Create posts with known sortable titles
+        let post1 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-B"), output: Post.self)
+        let post2 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-A"), output: Post.self)
+        let post3 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-C"), output: Post.self)
+        createdPostIds = [post1.id, post2.id, post3.id]
+
+        // Sort by title ascending
+        let posts: Collection<Post> = pb.collection("posts")
+        let sortQuery = PBSortQuery(PBSortDescriptor(\Post.title, order: .forward))
+        let result = try await posts.getList(sort: sortQuery, perPage: 100)
+        let ourTitles = result.items.compactMap {
+            $0.title.hasPrefix(prefix) ? $0.title : nil
+        }
+        #expect(ourTitles == ["\(prefix)-A", "\(prefix)-B", "\(prefix)-C"])
+    }
+
+    @Test
+    func getListWithSortDescending() async throws {
+        let pb = PocketBase(baseURL: "http://127.0.0.1:8090")
+        let prefix = "SORT-DESC-\(UUID().uuidString.prefix(4))"
+
+        let post1 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-B"), output: Post.self)
+        let post2 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-A"), output: Post.self)
+        let post3 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-C"), output: Post.self)
+        createdPostIds = [post1.id, post2.id, post3.id]
+
+        let posts: Collection<Post> = pb.collection("posts")
+        let sortQuery = PBSortQuery(PBSortDescriptor(\Post.title, order: .reverse))
+        let result = try await posts.getList(sort: sortQuery, perPage: 100)
+        let ourTitles = result.items.compactMap {
+            $0.title.hasPrefix(prefix) ? $0.title : nil
+        }
+        #expect(ourTitles == ["\(prefix)-C", "\(prefix)-B", "\(prefix)-A"])
+    }
+
+    @Test
+    func untypedGetListWithSortString() async throws {
+        let pb = PocketBase(baseURL: "http://127.0.0.1:8090")
+        let prefix = "UTSORT-\(UUID().uuidString.prefix(4))"
+
+        let post1 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-Z"), output: Post.self)
+        let post2 = try await pb.create(collection: "posts", record: CreatePost(title: "\(prefix)-A"), output: Post.self)
+        createdPostIds = [post1.id, post2.id]
+
+        // Use raw sort string on untyped API
+        let result = try await pb.getList(collection: "posts", model: Post.self, sort: "title", perPage: 100)
+        let ourTitles = result.items.compactMap {
+            $0.title.hasPrefix(prefix) ? $0.title : nil
+        }
+        #expect(ourTitles == ["\(prefix)-A", "\(prefix)-Z"])
+    }
+
+    @Test
+    func getListWithoutSort() async throws {
+        let pb = PocketBase(baseURL: "http://127.0.0.1:8090")
+
+        let posts: Collection<Post> = pb.collection("posts")
+        let result = try await posts.getList(perPage: 10)
+        // Should return results without error (default PocketBase order)
+        #expect(result.perPage == 10)
+    }
+
+    // MARK: Private
+
+    private func createRandomPostTitle() -> String {
+        "Test Post \(UUID().uuidString.prefix(8))"
+    }
+}

--- a/example/PocketBaseExample.xcodeproj/project.pbxproj
+++ b/example/PocketBaseExample.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 			mainGroup = A145E32C2E3E9C2F00A8B378;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				A145E3432E3E9C4A00A8B378 /* XCLocalSwiftPackageReference "../../pocketbase-swift-sdk" */,
+				A145E3432E3E9C4A00A8B378 /* XCLocalSwiftPackageReference ".." */,
 				A1A666D02EC3B71B00862426 /* XCRemoteSwiftPackageReference "swift-loadable" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -337,9 +337,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		A145E3432E3E9C4A00A8B378 /* XCLocalSwiftPackageReference "../../pocketbase-swift-sdk" */ = {
+		A145E3432E3E9C4A00A8B378 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../pocketbase-swift-sdk";
+			relativePath = "..";
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/example/PocketBaseExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/PocketBaseExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0bcb02154f34f833d159b5808c5720049b777a475ceefea5a735dc345c9a1262",
+  "originHash" : "67a18d3ebeb9489e499e21d28fe90d32a7d55f45f8c7a202922a884644874aa3",
   "pins" : [
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Recouse/EventSource.git",
       "state" : {
-        "revision" : "7b2f4f585d3927876bd76eaede9fdff779eff102",
-        "version" : "0.1.5"
+        "revision" : "d3d3a918c6b7aad080d2cf87cf7eaa87872e579b",
+        "version" : "0.1.8"
       }
     },
     {

--- a/example/PocketBaseExample/ContentView.swift
+++ b/example/PocketBaseExample/ContentView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 
 struct ContentView: View {
 
+    @Environment(\.pocketBase) private var pocketBase
+
     var body: some View {
         TabView {
             PostsListView()
@@ -19,6 +21,13 @@ struct ContentView: View {
                 .tabItem {
                     Label("Posts", systemImage: "list.bullet")
                 }
+            if let pocketBase {
+                PostsUIKitWrapper(pocketBase: pocketBase)
+                    .tag(Tabs.postsUIKit)
+                    .tabItem {
+                        Label("Posts UIKit", systemImage: "rectangle.grid.1x2")
+                    }
+            }
             AuthView()
                 .tag(Tabs.auth)
                 .tabItem {
@@ -36,5 +45,6 @@ struct ContentView: View {
 
 enum Tabs {
     case postList
+    case postsUIKit
     case auth
 }

--- a/example/PocketBaseExample/Feature/Auth/AuthView.swift
+++ b/example/PocketBaseExample/Feature/Auth/AuthView.swift
@@ -14,15 +14,15 @@ struct AuthView: View {
 
     // MARK: Internal
 
-    @Environment(\.pocketBase) var pocketBase
+    @PBAuthState private var auth
 
     var body: some View {
         NavigationStack(path: $path) {
             Group {
-                if isAuthenticated {
-                    AuthenticatedView(isAuthenticated: $isAuthenticated)
+                if auth.isAuthenticated {
+                    AuthenticatedView(onSignOut: { $auth.refresh() })
                 } else {
-                    LoginFormView(isAuthenticated: $isAuthenticated)
+                    LoginFormView(onLogin: { $auth.refresh() })
                 }
             }
             .navigationDestination(for: AuthDestination.self) { destination in
@@ -30,15 +30,11 @@ struct AuthView: View {
                 case .reset:
                     ResetView()
                 case .signUp:
-                    SignUpView(isAuthenticated: $isAuthenticated)
+                    SignUpView(onSignUp: { $auth.refresh() })
                 }
             }
         }
-        .onAppear {
-            isAuthenticated = pocketBase?.isAuthenticated ?? false
-        }
-        .onChange(of: isAuthenticated) { _, newValue in
-            // Clear navigation path when auth state changes
+        .onChange(of: auth.isAuthenticated) { _, newValue in
             if !newValue {
                 path = NavigationPath()
             }
@@ -48,8 +44,6 @@ struct AuthView: View {
     // MARK: Private
 
     @State private var path = NavigationPath()
-    @State private var isAuthenticated = false
-
 }
 
 #Preview("Logged Out") {

--- a/example/PocketBaseExample/Feature/Auth/AuthView.swift
+++ b/example/PocketBaseExample/Feature/Auth/AuthView.swift
@@ -35,7 +35,7 @@ struct AuthView: View {
             }
         }
         .onAppear {
-            isAuthenticated = pocketBase.isAuthenticated
+            isAuthenticated = pocketBase?.isAuthenticated ?? false
         }
         .onChange(of: isAuthenticated) { _, newValue in
             // Clear navigation path when auth state changes

--- a/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
+++ b/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
@@ -175,7 +175,10 @@ struct AuthenticatedView: View {
     @State private var errorMessage: String?
 
     private func loadCurrentUser() async {
-        guard let pb = pocketBase, let userId = pb.currentUserId else { return }
+        guard let pb = pocketBase, let userId = pb.currentUserId else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
 
         do {
             let userCollection: Collection<User> = pb.collection("users")
@@ -188,7 +191,10 @@ struct AuthenticatedView: View {
     }
 
     private func refreshToken() async {
-        guard let pb = pocketBase else { return }
+        guard let pb = pocketBase else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
         isRefreshing = true
         errorMessage = nil
 
@@ -205,7 +211,10 @@ struct AuthenticatedView: View {
     }
 
     private func loadAuthMethods() async {
-        guard let pb = pocketBase else { return }
+        guard let pb = pocketBase else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
         isLoadingAuthMethods = true
         errorMessage = nil
 

--- a/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
+++ b/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
@@ -175,10 +175,10 @@ struct AuthenticatedView: View {
     @State private var errorMessage: String?
 
     private func loadCurrentUser() async {
-        guard let userId = pocketBase.currentUserId else { return }
+        guard let pb = pocketBase, let userId = pb.currentUserId else { return }
 
         do {
-            let userCollection: Collection<User> = pocketBase.collection("users")
+            let userCollection: Collection<User> = pb.collection("users")
             currentUser = try await userCollection.getOne(id: userId)
             print("✅ Loaded current user: \(userId)")
         } catch {
@@ -188,11 +188,12 @@ struct AuthenticatedView: View {
     }
 
     private func refreshToken() async {
+        guard let pb = pocketBase else { return }
         isRefreshing = true
         errorMessage = nil
 
         do {
-            let refreshResult = try await pocketBase.authRefresh(userType: User.self)
+            let refreshResult = try await pb.authRefresh(userType: User.self)
             print("✅ Token refreshed: \(refreshResult.token)")
             currentUser = refreshResult.record
             isRefreshing = false
@@ -204,11 +205,12 @@ struct AuthenticatedView: View {
     }
 
     private func loadAuthMethods() async {
+        guard let pb = pocketBase else { return }
         isLoadingAuthMethods = true
         errorMessage = nil
 
         do {
-            authMethods = try await pocketBase.getAuthMethods()
+            authMethods = try await pb.getAuthMethods()
             print("✅ Auth methods loaded: password=\(authMethods?.password.enabled ?? false)")
             isLoadingAuthMethods = false
         } catch {
@@ -219,7 +221,7 @@ struct AuthenticatedView: View {
     }
 
     private func signOut() {
-        pocketBase.signOut()
+        pocketBase?.signOut()
         print("✅ User signed out")
         currentUser = nil
         authMethods = nil

--- a/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
+++ b/example/PocketBaseExample/Feature/Auth/AuthenticatedView.swift
@@ -14,7 +14,7 @@ struct AuthenticatedView: View {
     // MARK: Internal
 
     @Environment(\.pocketBase) var pocketBase
-    @Binding var isAuthenticated: Bool
+    var onSignOut: (() -> Void)?
 
     var body: some View {
         Form {
@@ -234,7 +234,7 @@ struct AuthenticatedView: View {
         print("✅ User signed out")
         currentUser = nil
         authMethods = nil
-        isAuthenticated = false
+        onSignOut?()
     }
 
     private func formatDate(_ dateString: String) -> String {
@@ -250,6 +250,5 @@ struct AuthenticatedView: View {
 }
 
 #Preview("Logged In") {
-    @Previewable @State var isAuthenticated = true
-    AuthenticatedView(isAuthenticated: $isAuthenticated)
+    AuthenticatedView(onSignOut: {})
 }

--- a/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
+++ b/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
@@ -68,7 +68,10 @@ struct LoginFormView: View {
     @State private var errorMessage: String?
 
     private func login() async {
-        guard let pb = pocketBase else { return }
+        guard let pb = pocketBase else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
         isLoading = true
         errorMessage = nil
 

--- a/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
+++ b/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
@@ -68,11 +68,12 @@ struct LoginFormView: View {
     @State private var errorMessage: String?
 
     private func login() async {
+        guard let pb = pocketBase else { return }
         isLoading = true
         errorMessage = nil
 
         do {
-            let authResult = try await pocketBase.authWithPassword(
+            let authResult = try await pb.authWithPassword(
                 email: email,
                 password: password,
                 userType: User.self)

--- a/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
+++ b/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
@@ -20,7 +20,7 @@ struct LoginFormView: View {
             Section {
                 TextField("Email", text: $email)
                     .textContentType(.emailAddress)
-                    .autocapitalization(.none)
+                    .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
 
                 SecureField("Password", text: $password)

--- a/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
+++ b/example/PocketBaseExample/Feature/Auth/LoginFormView.swift
@@ -13,7 +13,7 @@ struct LoginFormView: View {
     // MARK: Internal
 
     @Environment(\.pocketBase) var pocketBase
-    @Binding var isAuthenticated: Bool
+    var onLogin: (() -> Void)?
 
     var body: some View {
         Form {
@@ -83,7 +83,7 @@ struct LoginFormView: View {
 
             print("✅ User signed in successfully: \(authResult.record.id)")
             isLoading = false
-            isAuthenticated = true
+            onLogin?()
         } catch {
             print("❌ Sign in failed: \(error)")
             errorMessage = "Login failed: \(error.localizedDescription)"
@@ -94,6 +94,6 @@ struct LoginFormView: View {
 
 #Preview {
     NavigationStack {
-        LoginFormView(isAuthenticated: .constant(false))
+        LoginFormView(onLogin: {})
     }
 }

--- a/example/PocketBaseExample/Feature/Auth/ResetView.swift
+++ b/example/PocketBaseExample/Feature/Auth/ResetView.swift
@@ -34,7 +34,7 @@ struct ResetView: View {
             Section {
                 TextField("Email", text: $email)
                     .textContentType(.emailAddress)
-                    .autocapitalization(.none)
+                    .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
             } header: {
                 Text("Enter your email address")

--- a/example/PocketBaseExample/Feature/Auth/ResetView.swift
+++ b/example/PocketBaseExample/Feature/Auth/ResetView.swift
@@ -107,15 +107,16 @@ struct ResetView: View {
     @State private var selectedAction: ResetAction = .passwordReset
 
     private func performAction() async {
+        guard let pb = pocketBase else { return }
         isLoading = true
         errorMessage = nil
 
         do {
             if selectedAction == .passwordReset {
-                _ = try await pocketBase.requestPasswordReset(email: email)
+                _ = try await pb.requestPasswordReset(email: email)
                 print("✅ Password reset requested")
             } else {
-                _ = try await pocketBase.requestVerification(email: email)
+                _ = try await pb.requestVerification(email: email)
                 print("✅ Email verification requested")
             }
 

--- a/example/PocketBaseExample/Feature/Auth/ResetView.swift
+++ b/example/PocketBaseExample/Feature/Auth/ResetView.swift
@@ -107,7 +107,10 @@ struct ResetView: View {
     @State private var selectedAction: ResetAction = .passwordReset
 
     private func performAction() async {
-        guard let pb = pocketBase else { return }
+        guard let pb = pocketBase else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
         isLoading = true
         errorMessage = nil
 

--- a/example/PocketBaseExample/Feature/Auth/SignUpView.swift
+++ b/example/PocketBaseExample/Feature/Auth/SignUpView.swift
@@ -21,7 +21,7 @@ struct SignUpView: View {
             Section {
                 TextField("Email", text: $email)
                     .textContentType(.emailAddress)
-                    .autocapitalization(.none)
+                    .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
 
                 TextField("Name", text: $name)

--- a/example/PocketBaseExample/Feature/Auth/SignUpView.swift
+++ b/example/PocketBaseExample/Feature/Auth/SignUpView.swift
@@ -14,7 +14,7 @@ struct SignUpView: View {
 
     @Environment(\.pocketBase) var pocketBase
     @Environment(\.dismiss) var dismiss
-    @Binding var isAuthenticated: Bool
+    var onSignUp: (() -> Void)?
 
     var body: some View {
         Form {
@@ -125,7 +125,7 @@ struct SignUpView: View {
                 password: password,
                 userType: User.self)
 
-            isAuthenticated = true
+            onSignUp?()
             dismiss()
         } catch {
             print("❌ Sign up failed: \(error)")
@@ -137,6 +137,6 @@ struct SignUpView: View {
 
 #Preview {
     NavigationStack {
-        SignUpView(isAuthenticated: .constant(false))
+        SignUpView(onSignUp: {})
     }
 }

--- a/example/PocketBaseExample/Feature/Auth/SignUpView.swift
+++ b/example/PocketBaseExample/Feature/Auth/SignUpView.swift
@@ -98,7 +98,10 @@ struct SignUpView: View {
     }
 
     private func signUp() async {
-        guard let pb = pocketBase else { return }
+        guard let pb = pocketBase else {
+            errorMessage = "App is not configured. Please restart."
+            return
+        }
         isLoading = true
         errorMessage = nil
 

--- a/example/PocketBaseExample/Feature/Auth/SignUpView.swift
+++ b/example/PocketBaseExample/Feature/Auth/SignUpView.swift
@@ -98,6 +98,7 @@ struct SignUpView: View {
     }
 
     private func signUp() async {
+        guard let pb = pocketBase else { return }
         isLoading = true
         errorMessage = nil
 
@@ -108,7 +109,7 @@ struct SignUpView: View {
                 password: password,
                 passwordConfirm: passwordConfirm)
 
-            let authResult = try await pocketBase.signUp(
+            let authResult = try await pb.signUp(
                 dto: createUserDto,
                 userType: User.self)
 
@@ -116,7 +117,7 @@ struct SignUpView: View {
             isLoading = false
 
             // Sign in the newly created user
-            _ = try await pocketBase.authWithPassword(
+            _ = try await pb.authWithPassword(
                 email: email,
                 password: password,
                 userType: User.self)

--- a/example/PocketBaseExample/Feature/Posts/PostsListView.swift
+++ b/example/PocketBaseExample/Feature/Posts/PostsListView.swift
@@ -70,10 +70,10 @@ struct PostsListView: View {
 
     private func connectRealtime() async {
         guard let pb = pocketBase else { return }
-        realtime = pb.realtime(collection: "posts", onConnect: {
-            connected = true
-        }, onDisconnect: {
-            connected = false
+        realtime = pb.realtime(collection: "posts", onConnect: { [weak self] in
+            self?.connected = true
+        }, onDisconnect: { [weak self] in
+            self?.connected = false
             print("Disconnected from realtime")
         }, onEvent: { event in
             print("Received event: \(event.action) for record: \(event.record.id)")

--- a/example/PocketBaseExample/Feature/Posts/PostsListView.swift
+++ b/example/PocketBaseExample/Feature/Posts/PostsListView.swift
@@ -2,10 +2,7 @@
 //  PostsListView.swift
 //  PocketBaseExample
 //
-//  Created by Andrew Althage on 8/2/25.
-//
 
-import Loadable
 import PocketBase
 import SwiftUI
 
@@ -13,73 +10,81 @@ struct PostsListView: View {
 
     // MARK: Internal
 
-    @Environment(\.pocketBase) var pocketBase
+    @PBQuery(collection: "posts", sort: \Post.created, order: .reverse)
+    private var posts: [Post]
 
     var body: some View {
         NavigationStack {
             List {
-                LoadableView(postsData) { posts in
+                if $posts.isLoading, posts.isEmpty {
+                    HStack {
+                        Spacer()
+                        ProgressView("Loading posts...")
+                        Spacer()
+                    }
+                } else if let error = $posts.error {
+                    VStack {
+                        Text("Error loading posts")
+                            .font(.headline)
+                        Text(error.localizedDescription)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                        Button("Retry") {
+                            $posts.refresh()
+                        }
+                    }
+                } else {
                     ForEach(posts) { post in
                         NavigationLink(post.title) {
                             PostDetailView(post: post)
                         }
                     }
                 }
+
                 Section {
                     HStack {
                         Text("Realtime server \(connected ? "connected" : "disconnected")")
                     }
                 }
-            }.listStyle(.insetGrouped)
+            }
+            .listStyle(.insetGrouped)
             .listRowSpacing(8)
             .navigationTitle("Posts")
-            .task {
-                await loadPosts()
-            }.onAppear {
+            .refreshable {
+                $posts.refresh()
+            }
+            .onAppear {
                 Task {
                     await connectRealtime()
                 }
-            }.onDisappear {
-                guard let realtime else { return }
-                realtime.unsubscribe()
+            }
+            .onDisappear {
+                realtime?.unsubscribe()
             }
         }
     }
 
     // MARK: Private
 
-    @State private var postsData: Loadable<[Post]> = .initial
+    @Environment(\.pocketBase) private var pocketBase
     @State private var realtime: Realtime<Post>?
     @State private var connected = false
 
-    private func loadPosts() async {
-        do {
-            postsData = .loading
-            let postCollection: Collection<Post> = pocketBase.collection("posts")
-            let postResult = try await postCollection.getList()
-            postsData = .loaded(postResult.items)
-        } catch {
-            postsData = .error(error)
-        }
-    }
-
     private func connectRealtime() async {
-        do {
-            realtime = pocketBase.realtime(collection: "posts", onConnect: {
-                connected = true
-            }, onDisconnect: {
-                connected = false
-                print("Disconnected from realtime")
-            }, onEvent: { event in
-                print("Received event: \(event.action) for record: \(event.record.id)")
-            })
-            try await realtime?.subscribe()
-        } catch {
-            print("Error connecting to realtime: \(error)")
-        }
+        guard let pb = pocketBase else { return }
+        realtime = pb.realtime(collection: "posts", onConnect: {
+            connected = true
+        }, onDisconnect: {
+            connected = false
+            print("Disconnected from realtime")
+        }, onEvent: { event in
+            print("Received event: \(event.action) for record: \(event.record.id)")
+        })
+        try? await realtime?.subscribe()
     }
 }
 
 #Preview {
     PostsListView()
+        .environment(\.pocketBase, PocketBase(baseURL: "http://127.0.0.1:8090"))
 }

--- a/example/PocketBaseExample/Feature/Posts/PostsListView.swift
+++ b/example/PocketBaseExample/Feature/Posts/PostsListView.swift
@@ -53,10 +53,8 @@ struct PostsListView: View {
             .refreshable {
                 $posts.refresh()
             }
-            .onAppear {
-                Task {
-                    await connectRealtime()
-                }
+            .task {
+                await connectRealtime()
             }
             .onDisappear {
                 realtime?.unsubscribe()

--- a/example/PocketBaseExample/Feature/Posts/PostsListView.swift
+++ b/example/PocketBaseExample/Feature/Posts/PostsListView.swift
@@ -70,10 +70,10 @@ struct PostsListView: View {
 
     private func connectRealtime() async {
         guard let pb = pocketBase else { return }
-        realtime = pb.realtime(collection: "posts", onConnect: { [weak self] in
-            self?.connected = true
-        }, onDisconnect: { [weak self] in
-            self?.connected = false
+        realtime = pb.realtime(collection: "posts", onConnect: {
+            connected = true
+        }, onDisconnect: {
+            connected = false
             print("Disconnected from realtime")
         }, onEvent: { event in
             print("Received event: \(event.action) for record: \(event.record.id)")

--- a/example/PocketBaseExample/Feature/Posts/PostsListView.swift
+++ b/example/PocketBaseExample/Feature/Posts/PostsListView.swift
@@ -80,7 +80,11 @@ struct PostsListView: View {
         }, onEvent: { event in
             print("Received event: \(event.action) for record: \(event.record.id)")
         })
-        try? await realtime?.subscribe()
+        do {
+            try await realtime?.subscribe()
+        } catch {
+            print("Error connecting to realtime: \(error)")
+        }
     }
 }
 

--- a/example/PocketBaseExample/Feature/PostsUIKit/PostsUIKitViewController.swift
+++ b/example/PocketBaseExample/Feature/PostsUIKit/PostsUIKitViewController.swift
@@ -1,0 +1,131 @@
+//
+//  PostsUIKitViewController.swift
+//  PocketBaseExample
+//
+
+import PocketBase
+import UIKit
+
+// MARK: - PostsUIKitViewController
+
+final class PostsUIKitViewController: UITableViewController {
+
+    // MARK: Lifecycle
+
+    init(pocketBase: PocketBase) {
+        self.pocketBase = pocketBase
+        super.init(style: .plain)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Internal
+
+    var onSelectPost: ((Post) -> Void)?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Self.cellReuseID)
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(handleRefresh), for: .valueChanged)
+        performFetch()
+    }
+
+    // MARK: Private
+
+    private let pocketBase: PocketBase
+    private var posts: [Post] = []
+    private var isLoading = false
+    private var errorMessage: String?
+    private var fetchTask: Task<Void, Never>?
+
+    private static let cellReuseID = "PostCell"
+
+    private func performFetch() {
+        fetchTask?.cancel()
+        fetchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isLoading = true
+            self.errorMessage = nil
+            self.tableView.reloadData()
+
+            do {
+                let response = try await self.pocketBase.getList(
+                    collection: "posts",
+                    model: Post.self,
+                    sort: "-created"
+                )
+                self.posts = response.items
+            } catch is CancellationError {
+                return
+            } catch {
+                self.errorMessage = error.localizedDescription
+            }
+
+            self.isLoading = false
+            self.refreshControl?.endRefreshing()
+            self.tableView.reloadData()
+        }
+    }
+
+    @objc private func handleRefresh() {
+        performFetch()
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension PostsUIKitViewController {
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if isLoading, posts.isEmpty { return 1 }
+        if errorMessage != nil, posts.isEmpty { return 1 }
+        return posts.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: Self.cellReuseID, for: indexPath)
+
+        if isLoading, posts.isEmpty {
+            cell.textLabel?.text = "Loading posts..."
+            cell.detailTextLabel?.text = nil
+            cell.selectionStyle = .none
+            return cell
+        }
+
+        if let errorMessage, posts.isEmpty {
+            cell.textLabel?.text = errorMessage
+            cell.detailTextLabel?.text = "Tap to retry"
+            cell.textLabel?.textColor = .systemRed
+            cell.selectionStyle = .default
+            return cell
+        }
+
+        let post = posts[indexPath.row]
+        cell.textLabel?.textColor = .label
+        cell.textLabel?.text = post.title
+        cell.detailTextLabel?.text = post.created
+        cell.selectionStyle = .default
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension PostsUIKitViewController {
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        if errorMessage != nil, posts.isEmpty {
+            performFetch()
+            return
+        }
+
+        guard !posts.isEmpty, indexPath.row < posts.count else { return }
+        onSelectPost?(posts[indexPath.row])
+    }
+}

--- a/example/PocketBaseExample/Feature/PostsUIKit/PostsUIKitWrapper.swift
+++ b/example/PocketBaseExample/Feature/PostsUIKit/PostsUIKitWrapper.swift
@@ -1,0 +1,26 @@
+//
+//  PostsUIKitWrapper.swift
+//  PocketBaseExample
+//
+
+import PocketBase
+import SwiftUI
+
+// MARK: - PostsUIKitWrapper
+
+struct PostsUIKitWrapper: UIViewControllerRepresentable {
+    let pocketBase: PocketBase
+
+    func makeUIViewController(context: Context) -> PostsUIKitViewController {
+        let vc = PostsUIKitViewController(pocketBase: pocketBase)
+        vc.onSelectPost = { post in
+            let detailVC = UIHostingController(
+                rootView: NavigationStack { PostDetailView(post: post) }
+            )
+            vc.present(detailVC, animated: true)
+        }
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: PostsUIKitViewController, context: Context) {}
+}

--- a/example/PocketBaseExample/PocketBaseExampleApp.swift
+++ b/example/PocketBaseExample/PocketBaseExampleApp.swift
@@ -2,35 +2,20 @@
 //  PocketBaseExampleApp.swift
 //  PocketBaseExample
 //
-//  Created by Andrew Althage on 8/2/25.
-//
 
 import PocketBase
 import SwiftUI
-
-// MARK: - PB
-
-private struct PB: EnvironmentKey {
-    static let defaultValue = PocketBase(baseURL: "http://127.0.0.1:8090")
-}
-
-extension EnvironmentValues {
-    var pocketBase: PocketBase {
-        get {
-            self[PB.self]
-        } set {
-            self[PB.self] = newValue
-        }
-    }
-}
 
 // MARK: - PocketBaseExampleApp
 
 @main
 struct PocketBaseExampleApp: App {
+    @State private var pocketBase = PocketBase(baseURL: "http://127.0.0.1:8090")
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.pocketBase, pocketBase)
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `@PBQuery` and `@PBAuthState` property wrappers for SwiftUI (SwiftData-inspired API)
- New `PBSortDescriptor` / `PBSortQuery` typed sort support with KeyPath-based construction
- Comprehensive concurrency audit: `@MainActor` realtime callbacks, `@unchecked Sendable` where needed, builder struct conversion to non-mutating pattern
- New UIKit example screen proving the SDK works without SwiftUI
- `@Entry` macro for environment key, `@Observable` for state storage
- Fixed zombie realtime connection bug (PB_CONNECT decode failure)
- Fixed realtime thread safety (SSE event loop offloaded to concurrent Task)
- Fixed deprecated `.autocapitalization` in example app

## Test plan
- [x] All 65 SDK integration tests pass
- [x] SDK builds clean (Swift 6.1, iOS 17+, macOS 14+)
- [x] Example app builds and runs in iOS Simulator
- [x] Authentication flow works end-to-end (sign up, sign in, refresh, sign out)
- [x] Realtime subscriptions receive events
- [x] PBQuery fetches and displays list data
- [x] UIKit screen loads posts via raw async/await API
- [x] Pull-to-refresh works on both SwiftUI and UIKit screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)